### PR TITLE
2020/05/02 API 구현 완료 현황

### DIFF
--- a/EroojaNetwork/EroojaNetwork.xcodeproj/project.pbxproj
+++ b/EroojaNetwork/EroojaNetwork.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		B0C387A2245C6BBF006159F1 /* JobAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387A1245C6BBF006159F1 /* JobAPIRequest.swift */; };
 		B0C387A4245C6E4C006159F1 /* EroojaAPIRequest+Job.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387A3245C6E4C006159F1 /* EroojaAPIRequest+Job.swift */; };
 		B0C387B4245D1588006159F1 /* EroojaAPIRequest+User.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387B3245D1588006159F1 /* EroojaAPIRequest+User.swift */; };
+		B0C387BE245D8A6A006159F1 /* EroojaAPIRequest+Goal.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387BD245D8A6A006159F1 /* EroojaAPIRequest+Goal.swift */; };
+		B0C387C0245D8AAF006159F1 /* GoalAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387BF245D8AAF006159F1 /* GoalAPIRequest.swift */; };
 		B0C5F37D242F668900582AE5 /* EroojaURLConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C5F37C242F668900582AE5 /* EroojaURLConstant.swift */; };
 		B0C5F37F242F669900582AE5 /* BasicAPIError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C5F37E242F669900582AE5 /* BasicAPIError.swift */; };
 		B0C5F384242F66B600582AE5 /* HomeAPIRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C5F383242F66B600582AE5 /* HomeAPIRequest.swift */; };
@@ -32,6 +34,8 @@
 		B0C387A1245C6BBF006159F1 /* JobAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobAPIRequest.swift; sourceTree = "<group>"; };
 		B0C387A3245C6E4C006159F1 /* EroojaAPIRequest+Job.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EroojaAPIRequest+Job.swift"; sourceTree = "<group>"; };
 		B0C387B3245D1588006159F1 /* EroojaAPIRequest+User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EroojaAPIRequest+User.swift"; sourceTree = "<group>"; };
+		B0C387BD245D8A6A006159F1 /* EroojaAPIRequest+Goal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EroojaAPIRequest+Goal.swift"; sourceTree = "<group>"; };
+		B0C387BF245D8AAF006159F1 /* GoalAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalAPIRequest.swift; sourceTree = "<group>"; };
 		B0C5F37C242F668900582AE5 /* EroojaURLConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EroojaURLConstant.swift; sourceTree = "<group>"; };
 		B0C5F37E242F669900582AE5 /* BasicAPIError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicAPIError.swift; sourceTree = "<group>"; };
 		B0C5F383242F66B600582AE5 /* HomeAPIRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeAPIRequest.swift; sourceTree = "<group>"; };
@@ -109,8 +113,10 @@
 				B05DB162243F6DA300CA5D88 /* AuthAPIRequest.swift */,
 				B084D3C6245BDD330098DB2F /* UserAPIRequest.swift */,
 				B0C387A1245C6BBF006159F1 /* JobAPIRequest.swift */,
+				B0C387BF245D8AAF006159F1 /* GoalAPIRequest.swift */,
 				B0C387A3245C6E4C006159F1 /* EroojaAPIRequest+Job.swift */,
 				B0C387B3245D1588006159F1 /* EroojaAPIRequest+User.swift */,
+				B0C387BD245D8A6A006159F1 /* EroojaAPIRequest+Goal.swift */,
 			);
 			path = APIRequest;
 			sourceTree = "<group>";
@@ -223,8 +229,10 @@
 			files = (
 				B05DB163243F6DA300CA5D88 /* AuthAPIRequest.swift in Sources */,
 				B084D3C7245BDD330098DB2F /* UserAPIRequest.swift in Sources */,
+				B0C387BE245D8A6A006159F1 /* EroojaAPIRequest+Goal.swift in Sources */,
 				B084D3D9245BEC6C0098DB2F /* EroojaAPIConstant.swift in Sources */,
 				B0C387B4245D1588006159F1 /* EroojaAPIRequest+User.swift in Sources */,
+				B0C387C0245D8AAF006159F1 /* GoalAPIRequest.swift in Sources */,
 				B0C5F386242F66D100582AE5 /* EroojaAPIRequest.swift in Sources */,
 				B0C5F384242F66B600582AE5 /* HomeAPIRequest.swift in Sources */,
 				B0C387A4245C6E4C006159F1 /* EroojaAPIRequest+Job.swift in Sources */,

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -79,4 +79,21 @@ public extension EroojaAPIRequest {
             }
         })
     }
+    
+    func requestSearchGoalByID(goalId: String, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
+        let urlString = GoalAPIRequest.RequestType.searchGoalByGoalID(goalId).requestURL
+        AF.request(urlString).responseJSON(completionHandler: { response in
+            switch response.result {
+            case .success(_):
+                if let responseValue = (response.value as? NSDictionary) {
+                    completion(.success(responseValue))
+                } else {
+                    completion(.failure(.decodeError))
+                }
+            case .failure(let error):
+                ELog.error(error.localizedDescription)
+                completion(.failure(.urlRequestError)) // TEMP Error
+            }
+        })
+    }
 }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -1,0 +1,15 @@
+//
+//  EroojaAPIRequest+Goal.swift
+//  EroojaNetwork
+//
+//  Created by Denny on 2020/05/02.
+//  Copyright © 2020 Denny.K. All rights reserved.
+//
+
+import Foundation
+import Alamofire
+import EroojaCommon
+
+public extension EroojaAPIRequest {
+    
+}

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -12,6 +12,9 @@ import EroojaCommon
 
 public extension EroojaAPIRequest {
     func requestSearchGoal(searchModel: GoalSearchModel, token: String, completion: @escaping (Result<Bool, EroojaAPIError>) -> Void) {
-        
+        let urlString = GoalAPIRequest.RequestType.searchGoal(searchModel.goalFilterBy, searchModel.keyword, searchModel.fromDt,
+                                              searchModel.toDt, searchModel.jobInterestIds, searchModel.goalSortBy,
+                                              searchModel.direction, searchModel.size, searchModel.page).requestURL
+        ELog.debug("urlString : \(urlString)")
     }
 }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -35,11 +35,26 @@ public struct ToDoRequestModel: Codable {
 }
 
 public extension EroojaAPIRequest {
-    func requestSearchGoal(searchModel: GoalSearchModel, token: String, completion: @escaping (Result<Bool, EroojaAPIError>) -> Void) {
+    func requestSearchGoal(searchModel: GoalSearchModel, token: String, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
         let urlString = GoalAPIRequest.RequestType.searchGoal(searchModel.goalFilterBy, searchModel.keyword, searchModel.fromDt,
                                                               searchModel.toDt, searchModel.jobInterestIds, searchModel.goalSortBy,
                                                               searchModel.direction, searchModel.size, searchModel.page).requestURL
+        
         ELog.debug("urlString : \(urlString)")
+        
+        AF.request(urlString, method: .get).responseJSON(completionHandler: { response in
+            switch response.result {
+            case .success(_):
+                if let responseValue = (response.value as? NSDictionary) {
+                    completion(.success(responseValue))
+                } else {
+                    completion(.failure(.decodeError))
+                }
+            case .failure(let error):
+                ELog.error(error.localizedDescription)
+                completion(.failure(.urlRequestError)) // TEMP Error
+            }
+        })
     }
     
     func requestCreateGoal(createGoalModel: GoalCreateRequestModel?, token: String?, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -27,11 +27,25 @@ public struct GoalCreateRequestModel: Codable {
                 "interestIdList": interestIdList,
                 "todoList": todoList]
     }
+    
+    public init(title: String, description: String, isDateFixed: Bool, endDt: String, interestIdList: [Int], todoList: [ToDoRequestModel]) {
+        self.title = title
+        self.description = description
+        self.isDateFixed = isDateFixed
+        self.endDt = endDt
+        self.interestIdList = interestIdList
+        self.todoList = todoList
+    }
 }
 
 public struct ToDoRequestModel: Codable {
     var content: String
     var priority: Int
+    
+    public init(content: String, priority: Int) {
+        self.content = content
+        self.priority = priority
+    }
 }
 
 public extension EroojaAPIRequest {
@@ -57,15 +71,11 @@ public extension EroojaAPIRequest {
         })
     }
     
-    func requestCreateGoal(createGoalModel: GoalCreateRequestModel?, token: String?, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
+    func requestCreateGoal(createGoalModel: GoalCreateRequestModel, token: String, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
         let urlString = GoalAPIRequest.RequestType.createGoal.requestURL
         let headers: HTTPHeaders = ["Authorization" : "Bearer \(token)"]
-        let aa = GoalCreateRequestModel(title: "TestTest", description: "DesDes", isDateFixed: true, endDt: "2020-05-20T00:00:00", interestIdList: [1, 4, 6, 8], todoList: [ToDoRequestModel(content: "TODO1", priority: 0), ToDoRequestModel(content: "TODO2", priority: 1)])
-        let parameters = aa.dictionary
         
-        ELog.debug("parameters : \(parameters)")
-        
-        AF.request(urlString, method: .post, parameters: createGoalModel!, encoder: JSONParameterEncoder.default, headers: headers).responseJSON(completionHandler: { response in
+        AF.request(urlString, method: .post, parameters: createGoalModel, encoder: JSONParameterEncoder.default, headers: headers).responseJSON(completionHandler: { response in
             switch response.result {
             case .success(_):
                 if let responseValue = (response.value as? NSDictionary) {

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -11,5 +11,7 @@ import Alamofire
 import EroojaCommon
 
 public extension EroojaAPIRequest {
-    
+    func requestSearchGoal(searchModel: GoalSearchModel, token: String, completion: @escaping (Result<Bool, EroojaAPIError>) -> Void) {
+        
+    }
 }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -106,4 +106,21 @@ public extension EroojaAPIRequest {
             }
         })
     }
+    
+    func requestSearchGoalByInterest(interestId: String, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
+        let urlString = GoalAPIRequest.RequestType.searchGoalByInterestId(interestId).requestURL
+        AF.request(urlString).responseJSON(completionHandler: { response in
+            switch response.result {
+            case .success(_):
+                if let responseValue = (response.value as? NSDictionary) {
+                    completion(.success(responseValue))
+                } else {
+                    completion(.failure(.decodeError))
+                }
+            case .failure(let error):
+                ELog.error(error.localizedDescription)
+                completion(.failure(.urlRequestError)) // TEMP Error
+            }
+        })
+    }
 }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+Goal.swift
@@ -10,11 +10,58 @@ import Foundation
 import Alamofire
 import EroojaCommon
 
+// Create Goal
+public struct GoalCreateRequestModel: Codable {
+    var title: String
+    var description: String
+    var isDateFixed: Bool
+    var endDt: String
+    var interestIdList: [Int]
+    var todoList: [ToDoRequestModel]
+    
+    var dictionary: [String: Any] {
+        return ["title": title,
+                "description": description,
+                "isDateFixed": isDateFixed,
+                "endDt": endDt,
+                "interestIdList": interestIdList,
+                "todoList": todoList]
+    }
+}
+
+public struct ToDoRequestModel: Codable {
+    var content: String
+    var priority: Int
+}
+
 public extension EroojaAPIRequest {
     func requestSearchGoal(searchModel: GoalSearchModel, token: String, completion: @escaping (Result<Bool, EroojaAPIError>) -> Void) {
         let urlString = GoalAPIRequest.RequestType.searchGoal(searchModel.goalFilterBy, searchModel.keyword, searchModel.fromDt,
-                                              searchModel.toDt, searchModel.jobInterestIds, searchModel.goalSortBy,
-                                              searchModel.direction, searchModel.size, searchModel.page).requestURL
+                                                              searchModel.toDt, searchModel.jobInterestIds, searchModel.goalSortBy,
+                                                              searchModel.direction, searchModel.size, searchModel.page).requestURL
         ELog.debug("urlString : \(urlString)")
+    }
+    
+    func requestCreateGoal(createGoalModel: GoalCreateRequestModel?, token: String?, completion: @escaping (Result<NSDictionary, EroojaAPIError>) -> Void) {
+        let urlString = GoalAPIRequest.RequestType.createGoal.requestURL
+        let headers: HTTPHeaders = ["Authorization" : "Bearer \(token)"]
+        let aa = GoalCreateRequestModel(title: "TestTest", description: "DesDes", isDateFixed: true, endDt: "2020-05-20T00:00:00", interestIdList: [1, 4, 6, 8], todoList: [ToDoRequestModel(content: "TODO1", priority: 0), ToDoRequestModel(content: "TODO2", priority: 1)])
+        let parameters = aa.dictionary
+        
+        ELog.debug("parameters : \(parameters)")
+        
+        AF.request(urlString, method: .post, parameters: createGoalModel!, encoder: JSONParameterEncoder.default, headers: headers).responseJSON(completionHandler: { response in
+            switch response.result {
+            case .success(_):
+                if let responseValue = (response.value as? NSDictionary) {
+                    completion(.success(responseValue))
+                } else {
+                    completion(.failure(.decodeError))
+                }
+            case .failure(let error):
+                ELog.error(error.localizedDescription)
+                completion(.failure(.urlRequestError)) // TEMP Error
+            }
+        })
     }
 }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+User.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/EroojaAPIRequest+User.swift
@@ -3,7 +3,7 @@
 //  EroojaNetwork
 //
 //  Created by Denny on 2020/05/02.
-//  Copyright © 2020 김태인. All rights reserved.
+//  Copyright © 2020 Denny.K. All rights reserved.
 //
 
 import Foundation

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -10,15 +10,15 @@ import Foundation
 import EroojaCommon
 
 public struct GoalSearchModel {
-    var goalFilterBy: String
-    var keyword: String
-    var fromDt: String
-    var toDt: String
-    var jobInterestIds: [Int]
-    var goalSortBy: String
-    var direction: String
-    var size: Int
-    var page: Int
+    public var goalFilterBy: String
+    public var keyword: String
+    public var fromDt: String
+    public var toDt: String
+    public var jobInterestIds: [Int]
+    public var goalSortBy: String
+    public var direction: String
+    public var size: Int
+    public var page: Int
 }
 
 public struct GoalAPIRequest {

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -41,6 +41,7 @@ public struct GoalAPIRequest {
         // goalSortBy (String), direction (String), size (Int), page (Int)
         case searchGoal(String, String, String, String, [Int], String, String, Int, Int)
         case createGoal
+        case searchGoalByGoalID(String)
         
         var requestURL: URL{
             let compositeRequestURL: URL
@@ -72,6 +73,8 @@ public struct GoalAPIRequest {
                 compositeRequestURL = result
             case .createGoal:
                 compositeRequestURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("goal")
+            case let .searchGoalByGoalID(id):
+                compositeRequestURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("goal/\(id)")
             }
             return compositeRequestURL
         }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -50,13 +50,13 @@ public struct GoalAPIRequest {
                 for (index, interest) in jobInterestIds.enumerated() {
                     jobInterestIdString += "\(interest)"
                     if index < jobInterestIds.count - 1 {
-                        jobInterestIdString += ", "
+                        jobInterestIdString += ","
                     }
                 }
                 
                 let queryItems = [URLQueryItem(name: "goalFilterBy", value: goalFilterBy),
                                   URLQueryItem(name: "keyword", value: keyword),
-                                  URLQueryItem(name: "fromDt", value: keyword),
+                                  URLQueryItem(name: "fromDt", value: fromDt),
                                   URLQueryItem(name: "toDt", value: toDt),
                                   URLQueryItem(name: "jobInterestIds", value: jobInterestIdString),
                                   URLQueryItem(name: "goalSortBy", value: goalSortBy),
@@ -64,7 +64,7 @@ public struct GoalAPIRequest {
                                   URLQueryItem(name: "size", value: "\(size)"),
                                   URLQueryItem(name: "page", value: "\(page)")]
                 
-                var urlComps = URLComponents(string: EroojaURLConstant.hostURLString)!
+                var urlComps = URLComponents(string: "\(EroojaURLConstant.hostURLString)goal")!
                 urlComps.queryItems = queryItems
                 
                 let result = urlComps.url!

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -41,6 +41,7 @@ public struct GoalAPIRequest {
         // goalSortBy (String), direction (String), size (Int), page (Int)
         case searchGoal(String, String, String, String, [Int], String, String, Int, Int)
         case createGoal
+        case searchGoalByInterestId(String)
         case searchGoalByGoalID(String)
         
         var requestURL: URL{
@@ -71,6 +72,8 @@ public struct GoalAPIRequest {
                 let result = urlComps.url!
                 ELog.debug(result)
                 compositeRequestURL = result
+            case let .searchGoalByInterestId(interestId):
+                compositeRequestURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("goal/interest/\(interestId)")
             case .createGoal:
                 compositeRequestURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("goal")
             case let .searchGoalByGoalID(id):

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -40,6 +40,8 @@ public struct GoalAPIRequest {
         // goalFilterBy (String), keyword (String), fromDt (String), toDt (String), jobInterestIds ([Int])
         // goalSortBy (String), direction (String), size (Int), page (Int)
         case searchGoal(String, String, String, String, [Int], String, String, Int, Int)
+        case createGoal
+        
         var requestURL: URL{
             let compositeRequestURL: URL
             switch self {
@@ -68,6 +70,8 @@ public struct GoalAPIRequest {
                 let result = urlComps.url!
                 ELog.debug(result)
                 compositeRequestURL = result
+            case .createGoal:
+                compositeRequestURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("goal")
             }
             return compositeRequestURL
         }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -19,6 +19,20 @@ public struct GoalSearchModel {
     public var direction: String
     public var size: Int
     public var page: Int
+    
+    public init(goalFilterBy: String, keyword: String, fromDt: String, toDt: String,
+                jobInterestIds: [Int], goalSortBy: String,
+                direction: String, size: Int, page: Int) {
+        self.goalFilterBy = goalFilterBy
+        self.keyword = keyword
+        self.fromDt = fromDt
+        self.toDt = toDt
+        self.jobInterestIds = jobInterestIds
+        self.goalSortBy = goalSortBy
+        self.direction = direction
+        self.size = size
+        self.page = page
+    }
 }
 
 public struct GoalAPIRequest {
@@ -30,14 +44,13 @@ public struct GoalAPIRequest {
             let compositeRequestURL: URL
             switch self {
             case let .searchGoal(goalFilterBy, keyword, fromDt, toDt, jobInterestIds, goalSortBy, direction, size, page):
-                var jobInterestIdString = "["
+                var jobInterestIdString = ""
                 for (index, interest) in jobInterestIds.enumerated() {
                     jobInterestIdString += "\(interest)"
                     if index < jobInterestIds.count - 1 {
                         jobInterestIdString += ", "
                     }
                 }
-                jobInterestIdString += "]"
                 
                 let queryItems = [URLQueryItem(name: "goalFilterBy", value: goalFilterBy),
                                   URLQueryItem(name: "keyword", value: keyword),

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -1,0 +1,83 @@
+//
+//  GoalAPIRequest.swift
+//  EroojaNetwork
+//
+//  Created by Denny on 2020/05/02.
+//  Copyright © 2020 김태인. All rights reserved.
+//
+
+import Foundation
+
+public struct GoalAPIRequest {
+    enum RequestType {
+        // goalFilterBy (String), keyword (String), fromDt (String), toDt (String), jobInterestIds ([Int])
+        // goalSortBy (String), direction (String), size (Int), page (Int)
+        case searchGoal(String, String, String, String, [Int], String, String, Int, Int)
+        
+        case nicknameExist(String)
+        case nicknameUpdate(String)
+        case getUserFromToken
+        case userUpdate(String, String)
+        case profileImageUpdate
+        case getProfileImageHistory
+        
+        case getJobInterestList
+        case addJobInterestList([Int])
+        case addJobInterestItem(Int)
+        
+        
+        var requestURL: URL{
+            let compositeRequestURL: URL
+            let baseURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("member")
+            switch self {
+            case .searchGoal(goalFilterBy, keyword, fromDt, toDt, jobInterestIds, goalSortBy, direction, size, page):
+                
+                break
+            // /api/v1/member/nickname/duplicity
+            case .nicknameExist:
+                compositeRequestURL = baseURL.appendingPathComponent("nickname").appendingPathComponent("duplicity")
+            case .nicknameUpdate:
+                compositeRequestURL = baseURL.appendingPathComponent("nickname")
+            case .getUserFromToken, .userUpdate:
+                compositeRequestURL = baseURL
+            case .profileImageUpdate:
+                compositeRequestURL = baseURL.appendingPathComponent("image")
+            case .getProfileImageHistory:
+                compositeRequestURL = baseURL.appendingPathComponent("images")
+            case .getJobInterestList, .addJobInterestList:
+                compositeRequestURL = baseURL.appendingPathComponent("jobInterests")
+            case .addJobInterestItem:
+                compositeRequestURL = baseURL.appendingPathComponent("jobInterest")
+            }
+            return compositeRequestURL
+        }
+        
+        var requestParameter: [String: String] {
+            var parameters: [String: String] = [:]
+            switch self {
+            case let .nicknameExist(value):
+                parameters["nickname"] = value
+            case let .nicknameUpdate(value):
+                parameters["nickname"] = value
+            case let.userUpdate(nickname, imageURL):
+                parameters["nickname"] = nickname
+                parameters["imagePath"] = imageURL
+            case let.addJobInterestList(ids):
+                var idsString = "["
+                for (index, id) in ids.enumerated() {
+                    idsString += "\(id)"
+                    if index < ids.count - 1 {
+                        idsString += ", "
+                    }
+                }
+                idsString += "]"
+                parameters["ids"] = idsString
+            case let.addJobInterestItem(id):
+                parameters["id"] = "\(id)"
+            default:
+                break
+            }
+            return parameters
+        }
+    }
+}

--- a/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/GoalAPIRequest.swift
@@ -7,47 +7,54 @@
 //
 
 import Foundation
+import EroojaCommon
+
+public struct GoalSearchModel {
+    var goalFilterBy: String
+    var keyword: String
+    var fromDt: String
+    var toDt: String
+    var jobInterestIds: [Int]
+    var goalSortBy: String
+    var direction: String
+    var size: Int
+    var page: Int
+}
 
 public struct GoalAPIRequest {
     enum RequestType {
         // goalFilterBy (String), keyword (String), fromDt (String), toDt (String), jobInterestIds ([Int])
         // goalSortBy (String), direction (String), size (Int), page (Int)
         case searchGoal(String, String, String, String, [Int], String, String, Int, Int)
-        
-        case nicknameExist(String)
-        case nicknameUpdate(String)
-        case getUserFromToken
-        case userUpdate(String, String)
-        case profileImageUpdate
-        case getProfileImageHistory
-        
-        case getJobInterestList
-        case addJobInterestList([Int])
-        case addJobInterestItem(Int)
-        
-        
         var requestURL: URL{
             let compositeRequestURL: URL
-            let baseURL = URL(string: EroojaURLConstant.hostURLString)!.appendingPathComponent("member")
             switch self {
-            case .searchGoal(goalFilterBy, keyword, fromDt, toDt, jobInterestIds, goalSortBy, direction, size, page):
+            case let .searchGoal(goalFilterBy, keyword, fromDt, toDt, jobInterestIds, goalSortBy, direction, size, page):
+                var jobInterestIdString = "["
+                for (index, interest) in jobInterestIds.enumerated() {
+                    jobInterestIdString += "\(interest)"
+                    if index < jobInterestIds.count - 1 {
+                        jobInterestIdString += ", "
+                    }
+                }
+                jobInterestIdString += "]"
                 
-                break
-            // /api/v1/member/nickname/duplicity
-            case .nicknameExist:
-                compositeRequestURL = baseURL.appendingPathComponent("nickname").appendingPathComponent("duplicity")
-            case .nicknameUpdate:
-                compositeRequestURL = baseURL.appendingPathComponent("nickname")
-            case .getUserFromToken, .userUpdate:
-                compositeRequestURL = baseURL
-            case .profileImageUpdate:
-                compositeRequestURL = baseURL.appendingPathComponent("image")
-            case .getProfileImageHistory:
-                compositeRequestURL = baseURL.appendingPathComponent("images")
-            case .getJobInterestList, .addJobInterestList:
-                compositeRequestURL = baseURL.appendingPathComponent("jobInterests")
-            case .addJobInterestItem:
-                compositeRequestURL = baseURL.appendingPathComponent("jobInterest")
+                let queryItems = [URLQueryItem(name: "goalFilterBy", value: goalFilterBy),
+                                  URLQueryItem(name: "keyword", value: keyword),
+                                  URLQueryItem(name: "fromDt", value: keyword),
+                                  URLQueryItem(name: "toDt", value: toDt),
+                                  URLQueryItem(name: "jobInterestIds", value: jobInterestIdString),
+                                  URLQueryItem(name: "goalSortBy", value: goalSortBy),
+                                  URLQueryItem(name: "direction", value: direction),
+                                  URLQueryItem(name: "size", value: "\(size)"),
+                                  URLQueryItem(name: "page", value: "\(page)")]
+                
+                var urlComps = URLComponents(string: EroojaURLConstant.hostURLString)!
+                urlComps.queryItems = queryItems
+                
+                let result = urlComps.url!
+                ELog.debug(result)
+                compositeRequestURL = result
             }
             return compositeRequestURL
         }
@@ -55,25 +62,6 @@ public struct GoalAPIRequest {
         var requestParameter: [String: String] {
             var parameters: [String: String] = [:]
             switch self {
-            case let .nicknameExist(value):
-                parameters["nickname"] = value
-            case let .nicknameUpdate(value):
-                parameters["nickname"] = value
-            case let.userUpdate(nickname, imageURL):
-                parameters["nickname"] = nickname
-                parameters["imagePath"] = imageURL
-            case let.addJobInterestList(ids):
-                var idsString = "["
-                for (index, id) in ids.enumerated() {
-                    idsString += "\(id)"
-                    if index < ids.count - 1 {
-                        idsString += ", "
-                    }
-                }
-                idsString += "]"
-                parameters["ids"] = idsString
-            case let.addJobInterestItem(id):
-                parameters["id"] = "\(id)"
             default:
                 break
             }

--- a/EroojaNetwork/EroojaNetwork/APIRequest/JobAPIRequest.swift
+++ b/EroojaNetwork/EroojaNetwork/APIRequest/JobAPIRequest.swift
@@ -3,7 +3,7 @@
 //  EroojaNetwork
 //
 //  Created by Denny on 2020/05/01.
-//  Copyright © 2020 김태인. All rights reserved.
+//  Copyright © 2020 Denny.K. All rights reserved.
 //
 
 import Foundation

--- a/erooja.xcodeproj/project.pbxproj
+++ b/erooja.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		B0C3879C245C1051006159F1 /* UserAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C3879B245C1051006159F1 /* UserAPIViewController.swift */; };
 		B0C387AE245D058E006159F1 /* JobAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387AD245D058E006159F1 /* JobAPIViewController.swift */; };
 		B0C387C2245D8C1E006159F1 /* GoalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387C1245D8C1E006159F1 /* GoalModel.swift */; };
+		B0C387C8245D9006006159F1 /* GoalAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387C7245D9006006159F1 /* GoalAPIViewController.swift */; };
 		B0C5F38D242F671100582AE5 /* EroojaNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B02DFA8B242F64E100B6DF89 /* EroojaNetwork.framework */; };
 		B0C5F38E242F671100582AE5 /* EroojaNetwork.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B02DFA8B242F64E100B6DF89 /* EroojaNetwork.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B0D113EE24491C9800FE7C0C /* EroojaFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D113ED24491C9800FE7C0C /* EroojaFilterView.swift */; };
@@ -237,6 +238,7 @@
 		B0C3879B245C1051006159F1 /* UserAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIViewController.swift; sourceTree = "<group>"; };
 		B0C387AD245D058E006159F1 /* JobAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobAPIViewController.swift; sourceTree = "<group>"; };
 		B0C387C1245D8C1E006159F1 /* GoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalModel.swift; sourceTree = "<group>"; };
+		B0C387C7245D9006006159F1 /* GoalAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalAPIViewController.swift; sourceTree = "<group>"; };
 		B0D113ED24491C9800FE7C0C /* EroojaFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EroojaFilterView.swift; sourceTree = "<group>"; };
 		B0D11445244AF67700FE7C0C /* DetailGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGoalViewController.swift; sourceTree = "<group>"; };
 		B0D11446244AF67700FE7C0C /* DetailGoalViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailGoalViewController.xib; sourceTree = "<group>"; };
@@ -498,6 +500,7 @@
 				B0C38791245BFC5E006159F1 /* AccessTokenTestViewController.swift */,
 				B0C3879B245C1051006159F1 /* UserAPIViewController.swift */,
 				B0C387AD245D058E006159F1 /* JobAPIViewController.swift */,
+				B0C387C7245D9006006159F1 /* GoalAPIViewController.swift */,
 			);
 			path = APITest;
 			sourceTree = "<group>";
@@ -1022,6 +1025,7 @@
 				B0A8C5562433341D002B2C83 /* StartViewController.swift in Sources */,
 				B03D4A3224333C9D009180E9 /* BaseViewController.swift in Sources */,
 				B03D4A4024339001009180E9 /* EroojaProperty.swift in Sources */,
+				B0C387C8245D9006006159F1 /* GoalAPIViewController.swift in Sources */,
 				B0D11447244AF67700FE7C0C /* DetailGoalViewController.swift in Sources */,
 				B084D3C9245BE17C0098DB2F /* UserModel.swift in Sources */,
 				B0F98E8A2442EA5A00F7510E /* CreateGoalFirstCell.swift in Sources */,

--- a/erooja.xcodeproj/project.pbxproj
+++ b/erooja.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		B0C38792245BFC5E006159F1 /* AccessTokenTestViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C38791245BFC5E006159F1 /* AccessTokenTestViewController.swift */; };
 		B0C3879C245C1051006159F1 /* UserAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C3879B245C1051006159F1 /* UserAPIViewController.swift */; };
 		B0C387AE245D058E006159F1 /* JobAPIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387AD245D058E006159F1 /* JobAPIViewController.swift */; };
+		B0C387C2245D8C1E006159F1 /* GoalModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0C387C1245D8C1E006159F1 /* GoalModel.swift */; };
 		B0C5F38D242F671100582AE5 /* EroojaNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B02DFA8B242F64E100B6DF89 /* EroojaNetwork.framework */; };
 		B0C5F38E242F671100582AE5 /* EroojaNetwork.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B02DFA8B242F64E100B6DF89 /* EroojaNetwork.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B0D113EE24491C9800FE7C0C /* EroojaFilterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0D113ED24491C9800FE7C0C /* EroojaFilterView.swift */; };
@@ -235,6 +236,7 @@
 		B0C38791245BFC5E006159F1 /* AccessTokenTestViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessTokenTestViewController.swift; sourceTree = "<group>"; };
 		B0C3879B245C1051006159F1 /* UserAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserAPIViewController.swift; sourceTree = "<group>"; };
 		B0C387AD245D058E006159F1 /* JobAPIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JobAPIViewController.swift; sourceTree = "<group>"; };
+		B0C387C1245D8C1E006159F1 /* GoalModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoalModel.swift; sourceTree = "<group>"; };
 		B0D113ED24491C9800FE7C0C /* EroojaFilterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EroojaFilterView.swift; sourceTree = "<group>"; };
 		B0D11445244AF67700FE7C0C /* DetailGoalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailGoalViewController.swift; sourceTree = "<group>"; };
 		B0D11446244AF67700FE7C0C /* DetailGoalViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = DetailGoalViewController.xib; sourceTree = "<group>"; };
@@ -569,6 +571,7 @@
 				B084D3BC245BBE5B0098DB2F /* TokenModel.swift */,
 				B084D3C8245BE17C0098DB2F /* UserModel.swift */,
 				B084D3D3245BEBD40098DB2F /* JobTypeModel.swift */,
+				B0C387C1245D8C1E006159F1 /* GoalModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1001,6 +1004,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B0C387C2245D8C1E006159F1 /* GoalModel.swift in Sources */,
 				B0F98E6E2442914B00F7510E /* SearchTableViewCell.swift in Sources */,
 				B031CFBE243702DC00BDD599 /* EUIModalViewController.swift in Sources */,
 				B0D113EE24491C9800FE7C0C /* EroojaFilterView.swift in Sources */,

--- a/erooja/Models/GoalModel.swift
+++ b/erooja/Models/GoalModel.swift
@@ -36,6 +36,19 @@ public struct GoalTypeModel: Codable {
     var jobInterests: [JobInterestType]
 }
 
+public struct GoalSearchResponseModel: Codable {
+    var createDt: String
+    var updateDt: String
+    var id: Int
+    var title: String
+    var description: String
+    var joinCount: Int
+    var isEnd: Bool
+    var isDateFixed: Bool
+    var startDt: String
+    var endDt: String
+}
+
 public struct SortType: Codable {
     var sorted: Bool
     var unsorted: Bool

--- a/erooja/Models/GoalModel.swift
+++ b/erooja/Models/GoalModel.swift
@@ -1,0 +1,27 @@
+//
+//  GoalModel.swift
+//  erooja
+//
+//  Created by Denny on 2020/05/02.
+//  Copyright © 2020 김태인. All rights reserved.
+//
+
+import Foundation
+
+public struct GoalModel: Codable {
+    var content: [GoalTypeModel]
+}
+
+public struct GoalTypeModel: Codable {
+    var createDt: String
+    var updateDt: String
+    var id: Int
+    var title: String
+    var description: String
+    var joinCount: Int
+    var isEnd: Bool
+    var isDateFixed: Bool
+    var startDt: String
+    var endDt: String
+    var jobInterests: [JobInterestType]
+}

--- a/erooja/Models/GoalModel.swift
+++ b/erooja/Models/GoalModel.swift
@@ -10,6 +10,16 @@ import Foundation
 
 public struct GoalModel: Codable {
     var content: [GoalTypeModel]
+    var pageable: Pageable
+    var last: Bool
+    var totalPages: Int
+    var totalElements: Int
+    var size: Int
+    var number: Int
+    var numberOfElements: Int
+    var sort: SortType
+    var first: Bool
+    var empty: Bool
 }
 
 public struct GoalTypeModel: Codable {
@@ -24,4 +34,19 @@ public struct GoalTypeModel: Codable {
     var startDt: String
     var endDt: String
     var jobInterests: [JobInterestType]
+}
+
+public struct SortType: Codable {
+    var sorted: Bool
+    var unsorted: Bool
+    var empty: Bool
+}
+
+public struct Pageable: Codable {
+    var sort: SortType
+    var offset: Int
+    var pageNumber: Int
+    var pageSize: Int
+    var unpaged: Bool
+    var paged: Bool
 }

--- a/erooja/ViewHierarchy/UITest/APITest/APITestViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/APITestViewController.swift
@@ -73,6 +73,9 @@ extension APITestViewController: UITableViewDelegate, UITableViewDataSource {
         case .jobInterestAPI:
             let vc = storyboard?.instantiateViewController(withIdentifier: "apiTestJobInfoVC") as! JobAPIViewController
             navigationController?.pushViewController(vc, animated: true)
+        case .goalAPI:
+            let vc = storyboard?.instantiateViewController(withIdentifier: "apiTestGoalVC") as! GoalAPIViewController
+            navigationController?.pushViewController(vc, animated: true)
         default:
             break
         }

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -1,0 +1,24 @@
+//
+//  GoalAPIViewController.swift
+//  erooja
+//
+//  Created by Denny on 2020/05/02.
+//  Copyright © 2020 김태인. All rights reserved.
+//
+
+import Foundation
+import EroojaUI
+import EroojaNetwork
+import EroojaCommon
+
+public class GoalAPIViewController: BaseViewController {
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        
+    }
+    
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+    }
+}

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -24,6 +24,8 @@ public class GoalAPIViewController: BaseViewController {
     @IBOutlet weak var tfAccessToken: UITextField!
     @IBOutlet weak var tfGoalID: UITextField!
     
+    @IBOutlet weak var tfInterestID: UITextField!
+    
     @IBOutlet weak var searchGoalLogView: UITextView!
     
     // Create Goal
@@ -125,6 +127,36 @@ public class GoalAPIViewController: BaseViewController {
                 self.searchGoalLogView.text = "URLRequestError... Please Try Again"
             }
         })
+    }
+    
+    @IBAction func onClickSearchGoalByInterest(_ sender: UIButton) {
+        if let interestID = tfInterestID.text {
+            EroojaAPIRequest().requestSearchGoalByInterest(interestId: interestID, completion: { result in
+                switch result {
+                case .success(let item):
+                    var debugLogText = ""
+                    do {
+                        let decoder = JSONDecoder()
+                        let jsonData = try JSONSerialization.data(withJSONObject: item, options: .prettyPrinted)
+                        
+                        let goalItem = try decoder.decode(GoalModel.self, from: jsonData)
+                        
+                    } catch {
+                        if let messageData = item as? NSDictionary {
+                            debugLogText = ""
+                            let message: String = (messageData["message"] as? String) ?? ""
+                            debugLogText += "\(messageData["status"])\n"
+                            debugLogText += "\(message.removingPercentEncoding)\n"
+                            debugLogText += "JSON Decode Error"
+                            break
+                        }
+                    }
+                    self.searchGoalLogView.text = debugLogText
+                case .failure(_):
+                    self.searchGoalLogView.text = "URLRequestError... Please Try Again"
+                }
+            })
+        }
     }
     
     @IBAction func onClickSearchGoal(_ sender: UIButton) {

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -26,6 +26,21 @@ public class GoalAPIViewController: BaseViewController {
     
     @IBOutlet weak var searchGoalLogView: UITextView!
     
+    // Create Goal
+    @IBOutlet weak var tfCreateGoalTitle: UITextField!
+    @IBOutlet weak var tfCreateGoalDesc: UITextField!
+    @IBOutlet weak var tfCreateToDoTitle: UITextField!
+    @IBOutlet weak var lblNumberOfToDo: UILabel!
+    @IBOutlet weak var createGoalLogView: UITextView!
+    
+    @IBAction func didChangeValue(_ sender: UIStepper) {
+        self.lblNumberOfToDo.text = "Number of ToDo : \(sender.value)"
+    }
+    
+    @IBAction func onClickCreateGoal(_ sender: UIButton) {
+        
+    }
+    
     @IBAction func onClickSearchByGoalID(_ sender: UIButton) {
         EroojaAPIRequest().requestSearchGoalByID(goalId: tfGoalID.text!, completion: { result in
             //GoalSearchResponseModel

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -15,7 +15,11 @@ public class GoalAPIViewController: BaseViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
+        let searchModel = GoalSearchModel(goalFilterBy: "TITLE", keyword: "test", fromDt: "2020-04-22T00:18:26", toDt: "2020-05-02T00:00:00", jobInterestIds: [1, 2], goalSortBy: "TITLE", direction: "ASC", size: 10, page: 0)
         
+        EroojaAPIRequest().requestSearchGoal(searchModel: searchModel, token: "Test Token", completion: { result in
+            
+        })
     }
     
     public override func viewWillAppear(_ animated: Bool) {

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -30,18 +30,66 @@ public class GoalAPIViewController: BaseViewController {
     @IBOutlet weak var tfCreateGoalTitle: UITextField!
     @IBOutlet weak var tfCreateGoalDesc: UITextField!
     @IBOutlet weak var tfCreateToDoTitle: UITextField!
+    @IBOutlet weak var tfCreateGoalToken: UITextField!
     @IBOutlet weak var lblNumberOfToDo: UILabel!
     @IBOutlet weak var createGoalLogView: UITextView!
     
+    private var todoCount = 0
+    
     @IBAction func didChangeValue(_ sender: UIStepper) {
+        self.view.endEditing(true)
         self.lblNumberOfToDo.text = "Number of ToDo : \(sender.value)"
+        todoCount = Int(sender.value)
     }
     
     @IBAction func onClickCreateGoal(_ sender: UIButton) {
+        self.view.endEditing(true)
+        var todoList = [ToDoRequestModel]()
+        for index in 0..<todoCount {
+            todoList.append(ToDoRequestModel(content: "\(tfCreateToDoTitle.text!)\(index)", priority: index))
+        }
         
+        let model = GoalCreateRequestModel(title: tfCreateGoalTitle.text!, description: tfCreateGoalDesc.text!, isDateFixed: true, endDt: "2020-06-20T00:00:00", interestIdList: [1, 2], todoList: todoList)
+        if let token = tfCreateGoalToken.text {
+            EroojaAPIRequest().requestCreateGoal(createGoalModel: model, token: token, completion: { result in
+                switch result {
+                case .success(let item):
+                    var debugLogText = ""
+                    do {
+                        let decoder = JSONDecoder()
+                        let jsonData = try JSONSerialization.data(withJSONObject: item, options: .prettyPrinted)
+                        
+                        let goalItem = try decoder.decode(GoalSearchResponseModel.self, from: jsonData)
+                        debugLogText += "createDt : \(goalItem.createDt)\n"
+                        debugLogText += "updateDt : \(goalItem.updateDt)\n"
+                        debugLogText += "id : \(goalItem.id)\n"
+                        debugLogText += "title : \(goalItem.title)\n"
+                        debugLogText += "description : \(goalItem.description)\n"
+                        debugLogText += "joinCount : \(goalItem.joinCount)\n"
+                        debugLogText += "isEnd : \(goalItem.isEnd)\n"
+                        debugLogText += "isDateFixed : \(goalItem.isDateFixed)\n"
+                        debugLogText += "startDt : \(goalItem.startDt)\n"
+                        debugLogText += "endDt : \(goalItem.endDt)\n"
+                    } catch {
+                        if let messageData = item as? NSDictionary {
+                            debugLogText = ""
+                            let message: String = (messageData["message"] as? String) ?? ""
+                            debugLogText += "\(messageData["status"])\n"
+                            debugLogText += "\(message.removingPercentEncoding)\n"
+                            debugLogText += "JSON Decode Error"
+                            break
+                        }
+                    }
+                    self.createGoalLogView.text = debugLogText
+                case .failure(_):
+                    self.createGoalLogView.text = "URLRequestError... Please Try Again"
+                }
+            })
+        }
     }
     
     @IBAction func onClickSearchByGoalID(_ sender: UIButton) {
+        self.view.endEditing(true)
         EroojaAPIRequest().requestSearchGoalByID(goalId: tfGoalID.text!, completion: { result in
             //GoalSearchResponseModel
             switch result {
@@ -80,6 +128,7 @@ public class GoalAPIViewController: BaseViewController {
     }
     
     @IBAction func onClickSearchGoal(_ sender: UIButton) {
+        self.view.endEditing(true)
         var interests: [Int] = [Int]()
         for char in tfInterestIds.text!.split(separator: ",") {
             interests.append(Int(String(char))!)
@@ -108,5 +157,9 @@ public class GoalAPIViewController: BaseViewController {
     
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+    }
+    
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
 }

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -12,14 +12,40 @@ import EroojaNetwork
 import EroojaCommon
 
 public class GoalAPIViewController: BaseViewController {
+    @IBOutlet weak var tfFilterBy: UITextField!
+    @IBOutlet weak var tfKeyword: UITextField!
+    @IBOutlet weak var tfFromDt: UITextField!
+    @IBOutlet weak var tfToDt: UITextField!
+    @IBOutlet weak var tfInterestIds: UITextField!
+    @IBOutlet weak var tfDirection: UITextField!
+    @IBOutlet weak var tfSort: UITextField!
+    @IBOutlet weak var tfSize: UITextField!
+    @IBOutlet weak var tfPage: UITextField!
+    @IBOutlet weak var tfAccessToken: UITextField!
+    
+    @IBOutlet weak var searchGoalLogView: UITextView!
+    
+    @IBAction func onClickSearchGoal(_ sender: UIButton) {
+        var interests: [Int] = [Int]()
+        for char in tfInterestIds.text!.split(separator: ",") {
+            interests.append(Int(String(char))!)
+        }
+        
+        let searchModel = GoalSearchModel(goalFilterBy: tfFilterBy.text!, keyword: tfKeyword.text!, fromDt: tfFromDt.text!, toDt: tfToDt.text!, jobInterestIds: interests, goalSortBy: tfDirection.text!, direction: tfSort.text!, size: Int(tfSize.text!)!, page: Int(tfPage.text!)!)
+        
+        EroojaAPIRequest().requestSearchGoal(searchModel: searchModel, token: tfAccessToken.text!, completion: { result in
+            
+        })
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
         
         let searchModel = GoalSearchModel(goalFilterBy: "TITLE", keyword: "test", fromDt: "2020-04-22T00:18:26", toDt: "2020-05-02T00:00:00", jobInterestIds: [1, 2], goalSortBy: "TITLE", direction: "ASC", size: 10, page: 0)
         
-        EroojaAPIRequest().requestCreateGoal(createGoalModel: nil, token: nil, completion: { result in
-            
-        })
+//        EroojaAPIRequest().requestCreateGoal(createGoalModel: nil, token: nil, completion: { result in
+//
+//        })
         
         EroojaAPIRequest().requestSearchGoal(searchModel: searchModel, token: "Test Token", completion: { result in
             

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -22,8 +22,47 @@ public class GoalAPIViewController: BaseViewController {
     @IBOutlet weak var tfSize: UITextField!
     @IBOutlet weak var tfPage: UITextField!
     @IBOutlet weak var tfAccessToken: UITextField!
+    @IBOutlet weak var tfGoalID: UITextField!
     
     @IBOutlet weak var searchGoalLogView: UITextView!
+    
+    @IBAction func onClickSearchByGoalID(_ sender: UIButton) {
+        EroojaAPIRequest().requestSearchGoalByID(goalId: tfGoalID.text!, completion: { result in
+            //GoalSearchResponseModel
+            switch result {
+            case .success(let item):
+                var debugLogText = ""
+                do {
+                    let decoder = JSONDecoder()
+                    let jsonData = try JSONSerialization.data(withJSONObject: item, options: .prettyPrinted)
+                    
+                    let goalItem = try decoder.decode(GoalSearchResponseModel.self, from: jsonData)
+                    debugLogText += "createDt : \(goalItem.createDt)\n"
+                    debugLogText += "updateDt : \(goalItem.updateDt)\n"
+                    debugLogText += "id : \(goalItem.id)\n"
+                    debugLogText += "title : \(goalItem.title)\n"
+                    debugLogText += "description : \(goalItem.description)\n"
+                    debugLogText += "joinCount : \(goalItem.joinCount)\n"
+                    debugLogText += "isEnd : \(goalItem.isEnd)\n"
+                    debugLogText += "isDateFixed : \(goalItem.isDateFixed)\n"
+                    debugLogText += "startDt : \(goalItem.startDt)\n"
+                    debugLogText += "endDt : \(goalItem.endDt)\n"
+                } catch {
+                    if let messageData = item as? NSDictionary {
+                        debugLogText = ""
+                        let message: String = (messageData["message"] as? String) ?? ""
+                        debugLogText += "\(messageData["status"])\n"
+                        debugLogText += "\(message.removingPercentEncoding)\n"
+                        debugLogText += "JSON Decode Error"
+                        break
+                    }
+                }
+                self.searchGoalLogView.text = debugLogText
+            case .failure(_):
+                self.searchGoalLogView.text = "URLRequestError... Please Try Again"
+            }
+        })
+    }
     
     @IBAction func onClickSearchGoal(_ sender: UIButton) {
         var interests: [Int] = [Int]()

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -17,6 +17,10 @@ public class GoalAPIViewController: BaseViewController {
         
         let searchModel = GoalSearchModel(goalFilterBy: "TITLE", keyword: "test", fromDt: "2020-04-22T00:18:26", toDt: "2020-05-02T00:00:00", jobInterestIds: [1, 2], goalSortBy: "TITLE", direction: "ASC", size: 10, page: 0)
         
+        EroojaAPIRequest().requestCreateGoal(createGoalModel: nil, token: nil, completion: { result in
+            
+        })
+        
         EroojaAPIRequest().requestSearchGoal(searchModel: searchModel, token: "Test Token", completion: { result in
             
         })

--- a/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
+++ b/erooja/ViewHierarchy/UITest/APITest/GoalAPIViewController.swift
@@ -139,8 +139,9 @@ public class GoalAPIViewController: BaseViewController {
                         let decoder = JSONDecoder()
                         let jsonData = try JSONSerialization.data(withJSONObject: item, options: .prettyPrinted)
                         
-                        let goalItem = try decoder.decode(GoalModel.self, from: jsonData)
+                        debugLogText += item.debugDescription
                         
+//                        let goalItem = try decoder.decode(GoalModel.self, from: jsonData)
                     } catch {
                         if let messageData = item as? NSDictionary {
                             debugLogText = ""
@@ -148,7 +149,6 @@ public class GoalAPIViewController: BaseViewController {
                             debugLogText += "\(messageData["status"])\n"
                             debugLogText += "\(message.removingPercentEncoding)\n"
                             debugLogText += "JSON Decode Error"
-                            break
                         }
                     }
                     self.searchGoalLogView.text = debugLogText

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -652,7 +652,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1800"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1300"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
                                                 <rect key="frame" x="22" y="16" width="372" height="32"/>
@@ -676,6 +676,13 @@
                                                 <state key="normal" title="Search Goal"/>
                                                 <connections>
                                                     <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="kuI-g1-hXv"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TyX-Nd-vml">
+                                                <rect key="frame" x="22" y="1036" width="372" height="30"/>
+                                                <state key="normal" title="Create Goal"/>
+                                                <connections>
+                                                    <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="ruy-Ry-OTc"/>
                                                 </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
@@ -728,33 +735,67 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="page : 0" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
-                                                <rect key="frame" x="22" y="856" width="372" height="34"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Access Token" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SHc-wl-jog">
                                                 <rect key="frame" x="22" y="518" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
+                                                <rect key="frame" x="22" y="856" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
+                                                <rect key="frame" x="22" y="906" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ToDo Title (for debug)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Eoq-GU-M4X">
+                                                <rect key="frame" x="22" y="954" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of ToDo : 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ALh-5O-zUt">
+                                                <rect key="frame" x="22" y="1001.5" width="270" height="21"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="eQx-nX-Z7D">
+                                                <rect key="frame" x="300" y="996" width="94" height="32"/>
+                                            </stepper>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tqz-Xc-X77">
+                                                <rect key="frame" x="22" y="1074" width="372" height="191"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="191" id="zIX-0t-cNK"/>
+                                                </constraints>
+                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
+                                            <constraint firstItem="TyX-Nd-vml" firstAttribute="top" secondItem="eQx-nX-Z7D" secondAttribute="bottom" constant="8" id="179-Ly-eU3"/>
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="trailing" secondItem="PHm-pv-3p8" secondAttribute="trailing" id="1Af-hm-vXd"/>
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="top" secondItem="PHm-pv-3p8" secondAttribute="bottom" constant="18" id="23p-H9-v1O"/>
+                                            <constraint firstItem="Tqz-Xc-X77" firstAttribute="trailing" secondItem="TyX-Nd-vml" secondAttribute="trailing" id="3pw-oV-HJL"/>
                                             <constraint firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" constant="20" id="4tW-R7-eyL"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="leading" secondItem="7bi-hZ-uZv" secondAttribute="leading" id="79E-sa-7pY"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="8Vg-pG-l9j"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="centerX" secondItem="FEF-7s-mvR" secondAttribute="centerX" id="AfV-u6-yU7"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="trailing" secondItem="7bi-hZ-uZv" secondAttribute="trailing" id="D2c-fC-jqZ"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="HB0-5T-NTP"/>
-                                            <constraint firstAttribute="height" constant="1800" id="HLz-hQ-nwL"/>
+                                            <constraint firstAttribute="height" constant="1300" id="HLz-hQ-nwL"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Hjp-ea-GuB"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
+                                            <constraint firstItem="AbB-vy-yCh" firstAttribute="leading" secondItem="CWx-3b-HSp" secondAttribute="leading" id="QKY-Xi-dne"/>
+                                            <constraint firstItem="AbB-vy-yCh" firstAttribute="top" secondItem="CWx-3b-HSp" secondAttribute="bottom" constant="16" id="RMe-v0-Z5G"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="leading" secondItem="6T1-FQ-5F0" secondAttribute="leading" id="Rhp-sv-cPf"/>
+                                            <constraint firstItem="Eoq-GU-M4X" firstAttribute="top" secondItem="AbB-vy-yCh" secondAttribute="bottom" constant="14" id="RiS-ew-Ybh"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="trailing" secondItem="m1C-rK-hr6" secondAttribute="trailing" id="RjK-4s-pQ6"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="leading" secondItem="fzM-yi-5iN" secondAttribute="leading" constant="22" id="S2r-3F-e2W"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="leading" secondItem="YiU-0q-WEb" secondAttribute="leading" id="TgI-7s-Y0q"/>
@@ -762,9 +803,13 @@
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="leading" secondItem="PHm-pv-3p8" secondAttribute="leading" id="Ust-Yd-mVU"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="leading" secondItem="ZCa-Ky-sJk" secondAttribute="leading" id="UtW-hr-unA"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="leading" secondItem="17V-Z9-gUh" secondAttribute="leading" id="Uw8-Vc-NA6"/>
+                                            <constraint firstItem="Tqz-Xc-X77" firstAttribute="leading" secondItem="TyX-Nd-vml" secondAttribute="leading" id="VeZ-cz-GzN"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="trailing" secondItem="ZCa-Ky-sJk" secondAttribute="trailing" id="Vee-Ql-CM4"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="WxR-24-d7Z"/>
+                                            <constraint firstItem="Eoq-GU-M4X" firstAttribute="leading" secondItem="AbB-vy-yCh" secondAttribute="leading" id="XJi-md-Tq8"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="trailing" secondItem="ALd-1x-D8s" secondAttribute="trailing" id="XVu-xL-n1F"/>
+                                            <constraint firstItem="eQx-nX-Z7D" firstAttribute="top" secondItem="Eoq-GU-M4X" secondAttribute="bottom" constant="8" id="XaC-bg-6NM"/>
+                                            <constraint firstItem="eQx-nX-Z7D" firstAttribute="leading" secondItem="ALh-5O-zUt" secondAttribute="trailing" constant="8" id="aFa-0N-oZE"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="top" secondItem="ALd-1x-D8s" secondAttribute="bottom" constant="16" id="aYb-sW-hcH"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="leading" secondItem="m1C-rK-hr6" secondAttribute="leading" id="ags-I9-3lc"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="top" secondItem="YiU-0q-WEb" secondAttribute="bottom" constant="16" id="cgF-Fs-xXM"/>
@@ -772,21 +817,29 @@
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" id="cv4-P7-WXS"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="top" secondItem="rv1-g2-bCc" secondAttribute="bottom" constant="20" id="evR-vw-kkJ"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="trailing" secondItem="17V-Z9-gUh" secondAttribute="trailing" id="fCq-0w-3ic"/>
+                                            <constraint firstItem="Tqz-Xc-X77" firstAttribute="top" secondItem="TyX-Nd-vml" secondAttribute="bottom" constant="8" id="gya-wp-vJt"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="leading" secondItem="FEF-7s-mvR" secondAttribute="leading" id="hvC-z5-Hcw"/>
+                                            <constraint firstItem="Eoq-GU-M4X" firstAttribute="trailing" secondItem="AbB-vy-yCh" secondAttribute="trailing" id="jIQ-md-904"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="top" secondItem="m1C-rK-hr6" secondAttribute="bottom" constant="25" id="kDr-wb-yEl"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="leading" secondItem="ALd-1x-D8s" secondAttribute="leading" id="khr-CV-Y3J"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="SHc-wl-jog" secondAttribute="bottom" constant="16" id="mZG-Jc-mqr"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="leading" secondItem="66f-ut-xc9" secondAttribute="leading" id="nev-1X-dJG"/>
+                                            <constraint firstItem="TyX-Nd-vml" firstAttribute="trailing" secondItem="eQx-nX-Z7D" secondAttribute="trailing" id="npT-xJ-fyq"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="o4x-Ae-iwf"/>
+                                            <constraint firstItem="TyX-Nd-vml" firstAttribute="leading" secondItem="ALh-5O-zUt" secondAttribute="leading" id="oeA-oE-vRi"/>
+                                            <constraint firstItem="eQx-nX-Z7D" firstAttribute="trailing" secondItem="Eoq-GU-M4X" secondAttribute="trailing" id="pGI-Jr-O2p"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="pU0-fB-Mqr"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="qcI-5N-bIk"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="trailing" secondItem="YiU-0q-WEb" secondAttribute="trailing" id="qik-W9-4fN"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="trailing" secondItem="6T1-FQ-5F0" secondAttribute="trailing" id="rG9-ZG-65j"/>
+                                            <constraint firstItem="AbB-vy-yCh" firstAttribute="trailing" secondItem="CWx-3b-HSp" secondAttribute="trailing" id="rO8-Sb-TdR"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="sMn-xX-ubu"/>
+                                            <constraint firstItem="ALh-5O-zUt" firstAttribute="leading" secondItem="Eoq-GU-M4X" secondAttribute="leading" id="sYz-jO-2l3"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="top" secondItem="FEF-7s-mvR" secondAttribute="bottom" constant="10" id="uYL-jT-f30"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="top" secondItem="fzM-yi-5iN" secondAttribute="top" constant="16" id="uud-EY-siF"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="2" id="vsW-DS-Tp7"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="yda-eO-4bt"/>
+                                            <constraint firstItem="ALh-5O-zUt" firstAttribute="centerY" secondItem="eQx-nX-Z7D" secondAttribute="centerY" id="zjH-um-USI"/>
                                         </constraints>
                                     </view>
                                 </subviews>
@@ -824,7 +877,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JG6-qx-xxl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="3406" y="1572"/>
+            <point key="canvasLocation" x="3405.7971014492755" y="1571.6517857142856"/>
         </scene>
     </scenes>
 </document>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -640,5 +640,150 @@
             </objects>
             <point key="canvasLocation" x="2562" y="1572"/>
         </scene>
+        <!--GoalAPI View Controller-->
+        <scene sceneID="lqi-xw-ZxL">
+            <objects>
+                <viewController storyboardIdentifier="apiTestJobInfoVC" id="IhW-NR-HZQ" customClass="GoalAPIViewController" customModule="erooja" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="bZx-Zn-bZL">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vcZ-Vs-op7">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="900"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
+                                                <rect key="frame" x="22" y="16" width="372" height="32"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="NONE | TITLE | DESCRIPTION" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="66f-ut-xc9">
+                                                <rect key="frame" x="22" y="58" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-bz-J4f">
+                                                <rect key="frame" x="22" y="509" width="372" height="30"/>
+                                                <state key="normal" title="Search Goal"/>
+                                            </button>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
+                                                <rect key="frame" x="22" y="541" width="372" height="191"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="191" id="j9r-aF-1gV"/>
+                                                </constraints>
+                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Keyword" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="YiU-0q-WEb">
+                                                <rect key="frame" x="22" y="107" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="yyyyMMddThh:mm:ss" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="7bi-hZ-uZv">
+                                                <rect key="frame" x="22" y="157" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="yyyyMMddThh:mm:ss" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="17V-Z9-gUh">
+                                                <rect key="frame" x="22" y="207" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="0,1,2,3, ..." textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ZCa-Ky-sJk">
+                                                <rect key="frame" x="22" y="258" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ID, TITLE, START_DT, END_DT, JOIN_CNT" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ALd-1x-D8s">
+                                                <rect key="frame" x="22" y="310" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ASC | DESC" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6T1-FQ-5F0">
+                                                <rect key="frame" x="22" y="360" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="size : 0" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="PHm-pv-3p8">
+                                                <rect key="frame" x="22" y="412" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="page : 0" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="rv1-g2-bCc">
+                                                <rect key="frame" x="22" y="464" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstItem="rv1-g2-bCc" firstAttribute="trailing" secondItem="PHm-pv-3p8" secondAttribute="trailing" id="1Af-hm-vXd"/>
+                                            <constraint firstItem="rv1-g2-bCc" firstAttribute="top" secondItem="PHm-pv-3p8" secondAttribute="bottom" constant="18" id="23p-H9-v1O"/>
+                                            <constraint firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" constant="20" id="4tW-R7-eyL"/>
+                                            <constraint firstItem="17V-Z9-gUh" firstAttribute="leading" secondItem="7bi-hZ-uZv" secondAttribute="leading" id="79E-sa-7pY"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="rv1-g2-bCc" secondAttribute="bottom" constant="11" id="7h0-PX-CMk"/>
+                                            <constraint firstItem="66f-ut-xc9" firstAttribute="centerX" secondItem="FEF-7s-mvR" secondAttribute="centerX" id="AfV-u6-yU7"/>
+                                            <constraint firstItem="17V-Z9-gUh" firstAttribute="trailing" secondItem="7bi-hZ-uZv" secondAttribute="trailing" id="D2c-fC-jqZ"/>
+                                            <constraint firstAttribute="height" constant="900" id="HLz-hQ-nwL"/>
+                                            <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
+                                            <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
+                                            <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
+                                            <constraint firstItem="PHm-pv-3p8" firstAttribute="leading" secondItem="6T1-FQ-5F0" secondAttribute="leading" id="Rhp-sv-cPf"/>
+                                            <constraint firstItem="FEF-7s-mvR" firstAttribute="leading" secondItem="fzM-yi-5iN" secondAttribute="leading" constant="22" id="S2r-3F-e2W"/>
+                                            <constraint firstItem="7bi-hZ-uZv" firstAttribute="leading" secondItem="YiU-0q-WEb" secondAttribute="leading" id="TgI-7s-Y0q"/>
+                                            <constraint firstItem="PHm-pv-3p8" firstAttribute="top" secondItem="6T1-FQ-5F0" secondAttribute="bottom" constant="18" id="U9C-dq-udm"/>
+                                            <constraint firstItem="rv1-g2-bCc" firstAttribute="leading" secondItem="PHm-pv-3p8" secondAttribute="leading" id="Ust-Yd-mVU"/>
+                                            <constraint firstItem="ALd-1x-D8s" firstAttribute="leading" secondItem="ZCa-Ky-sJk" secondAttribute="leading" id="UtW-hr-unA"/>
+                                            <constraint firstItem="ZCa-Ky-sJk" firstAttribute="leading" secondItem="17V-Z9-gUh" secondAttribute="leading" id="Uw8-Vc-NA6"/>
+                                            <constraint firstItem="ALd-1x-D8s" firstAttribute="trailing" secondItem="ZCa-Ky-sJk" secondAttribute="trailing" id="Vee-Ql-CM4"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="WxR-24-d7Z"/>
+                                            <constraint firstItem="6T1-FQ-5F0" firstAttribute="trailing" secondItem="ALd-1x-D8s" secondAttribute="trailing" id="XVu-xL-n1F"/>
+                                            <constraint firstItem="6T1-FQ-5F0" firstAttribute="top" secondItem="ALd-1x-D8s" secondAttribute="bottom" constant="16" id="aYb-sW-hcH"/>
+                                            <constraint firstItem="7bi-hZ-uZv" firstAttribute="top" secondItem="YiU-0q-WEb" secondAttribute="bottom" constant="16" id="cgF-Fs-xXM"/>
+                                            <constraint firstItem="YiU-0q-WEb" firstAttribute="top" secondItem="66f-ut-xc9" secondAttribute="bottom" constant="15" id="cmI-ru-byd"/>
+                                            <constraint firstItem="YiU-0q-WEb" firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" id="cv4-P7-WXS"/>
+                                            <constraint firstItem="ZCa-Ky-sJk" firstAttribute="trailing" secondItem="17V-Z9-gUh" secondAttribute="trailing" id="fCq-0w-3ic"/>
+                                            <constraint firstItem="66f-ut-xc9" firstAttribute="leading" secondItem="FEF-7s-mvR" secondAttribute="leading" id="hvC-z5-Hcw"/>
+                                            <constraint firstItem="6T1-FQ-5F0" firstAttribute="leading" secondItem="ALd-1x-D8s" secondAttribute="leading" id="khr-CV-Y3J"/>
+                                            <constraint firstItem="YiU-0q-WEb" firstAttribute="leading" secondItem="66f-ut-xc9" secondAttribute="leading" id="nev-1X-dJG"/>
+                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="pU0-fB-Mqr"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="qcI-5N-bIk"/>
+                                            <constraint firstItem="7bi-hZ-uZv" firstAttribute="trailing" secondItem="YiU-0q-WEb" secondAttribute="trailing" id="qik-W9-4fN"/>
+                                            <constraint firstItem="PHm-pv-3p8" firstAttribute="trailing" secondItem="6T1-FQ-5F0" secondAttribute="trailing" id="rG9-ZG-65j"/>
+                                            <constraint firstItem="66f-ut-xc9" firstAttribute="top" secondItem="FEF-7s-mvR" secondAttribute="bottom" constant="10" id="uYL-jT-f30"/>
+                                            <constraint firstItem="FEF-7s-mvR" firstAttribute="top" secondItem="fzM-yi-5iN" secondAttribute="top" constant="16" id="uud-EY-siF"/>
+                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="2" id="vsW-DS-Tp7"/>
+                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="yda-eO-4bt"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="fzM-yi-5iN" secondAttribute="bottom" id="SrZ-OI-MTi"/>
+                                    <constraint firstItem="fzM-yi-5iN" firstAttribute="top" secondItem="vcZ-Vs-op7" secondAttribute="top" id="ewJ-cb-bhS"/>
+                                    <constraint firstAttribute="trailing" secondItem="fzM-yi-5iN" secondAttribute="trailing" id="gAS-3c-egr"/>
+                                    <constraint firstItem="fzM-yi-5iN" firstAttribute="width" secondItem="vcZ-Vs-op7" secondAttribute="width" id="lJK-0Q-PXh"/>
+                                    <constraint firstItem="fzM-yi-5iN" firstAttribute="leading" secondItem="vcZ-Vs-op7" secondAttribute="leading" id="lnu-ol-CfH"/>
+                                </constraints>
+                            </scrollView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="vcZ-Vs-op7" firstAttribute="top" secondItem="TID-fE-30B" secondAttribute="top" id="07A-YK-zIf"/>
+                            <constraint firstItem="TID-fE-30B" firstAttribute="trailing" secondItem="vcZ-Vs-op7" secondAttribute="trailing" id="LMb-gA-V1e"/>
+                            <constraint firstItem="vcZ-Vs-op7" firstAttribute="leading" secondItem="TID-fE-30B" secondAttribute="leading" id="TX8-tF-RJA"/>
+                            <constraint firstItem="TID-fE-30B" firstAttribute="bottom" secondItem="vcZ-Vs-op7" secondAttribute="bottom" id="mMm-G1-22j"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="TID-fE-30B"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="JG6-qx-xxl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3406" y="1572"/>
+        </scene>
     </scenes>
 </document>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -652,7 +652,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1420"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1550"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
                                                 <rect key="frame" x="22" y="16" width="372" height="32"/>
@@ -661,7 +661,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Goal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKs-sO-l08">
-                                                <rect key="frame" x="22" y="896" width="372" height="32"/>
+                                                <rect key="frame" x="22" y="996" width="372" height="32"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -672,28 +672,35 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-bz-J4f">
-                                                <rect key="frame" x="22" y="608" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="658" width="372" height="30"/>
                                                 <state key="normal" title="Search Goal"/>
                                                 <connections>
                                                     <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="kuI-g1-hXv"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDc-P6-EV3">
-                                                <rect key="frame" x="22" y="646" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="696" width="372" height="30"/>
                                                 <state key="normal" title="Search Goal by id"/>
                                                 <connections>
                                                     <action selector="onClickSearchByGoalID:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="HlY-bD-cSq"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eEY-QJ-WyR">
+                                                <rect key="frame" x="22" y="734" width="372" height="30"/>
+                                                <state key="normal" title="Search Goal by interest id"/>
+                                                <connections>
+                                                    <action selector="onClickSearchGoalByInterest:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="qz6-FS-jx8"/>
+                                                </connections>
+                                            </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TyX-Nd-vml">
-                                                <rect key="frame" x="22" y="1166" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="1266" width="372" height="30"/>
                                                 <state key="normal" title="Create Goal"/>
                                                 <connections>
                                                     <action selector="onClickCreateGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="yxL-Ga-dH6"/>
                                                 </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
-                                                <rect key="frame" x="22" y="680" width="372" height="191"/>
+                                                <rect key="frame" x="22" y="780" width="372" height="191"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="191" id="j9r-aF-1gV"/>
@@ -703,7 +710,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tqz-Xc-X77">
-                                                <rect key="frame" x="22" y="1204" width="372" height="191"/>
+                                                <rect key="frame" x="22" y="1304" width="372" height="191"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="191" id="zIX-0t-cNK"/>
@@ -763,34 +770,39 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
-                                                <rect key="frame" x="22" y="986" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="1086" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="AccessToken" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-Mw-sXv">
                                                 <rect key="frame" x="22" y="1036" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
+                                                <rect key="frame" x="22" y="1136" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ToDo Title (for debug)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Eoq-GU-M4X">
-                                                <rect key="frame" x="22" y="1084" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="1184" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of ToDo : 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ALh-5O-zUt">
-                                                <rect key="frame" x="22" y="1131.5" width="270" height="21"/>
+                                                <rect key="frame" x="22" y="1231.5" width="270" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="eQx-nX-Z7D">
-                                                <rect key="frame" x="300" y="1126" width="94" height="32"/>
+                                                <rect key="frame" x="300" y="1226" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="didChangeValue:" destination="IhW-NR-HZQ" eventType="valueChanged" id="Uy6-Zg-ZaP"/>
                                                 </connections>
                                             </stepper>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="AccessToken" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-Mw-sXv">
-                                                <rect key="frame" x="22" y="936" width="372" height="34"/>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Interest ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Yh-Kf-8bz">
+                                                <rect key="frame" x="22" y="616" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
@@ -803,7 +815,9 @@
                                             <constraint firstItem="Tqz-Xc-X77" firstAttribute="trailing" secondItem="TyX-Nd-vml" secondAttribute="trailing" id="3pw-oV-HJL"/>
                                             <constraint firstItem="n6U-Mw-sXv" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="3sj-np-HPT"/>
                                             <constraint firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" constant="20" id="4tW-R7-eyL"/>
+                                            <constraint firstItem="2Yh-Kf-8bz" firstAttribute="leading" secondItem="ILT-mG-F3z" secondAttribute="leading" id="5og-Mm-e1H"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="leading" secondItem="7bi-hZ-uZv" secondAttribute="leading" id="79E-sa-7pY"/>
+                                            <constraint firstItem="eEY-QJ-WyR" firstAttribute="top" secondItem="GDc-P6-EV3" secondAttribute="bottom" constant="8" id="8LW-TJ-Eh8"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="8Vg-pG-l9j"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="centerX" secondItem="FEF-7s-mvR" secondAttribute="centerX" id="AfV-u6-yU7"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="trailing" secondItem="7bi-hZ-uZv" secondAttribute="trailing" id="D2c-fC-jqZ"/>
@@ -811,12 +825,13 @@
                                             <constraint firstItem="GDc-P6-EV3" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="GiL-Jf-Csd"/>
                                             <constraint firstItem="ILT-mG-F3z" firstAttribute="trailing" secondItem="SHc-wl-jog" secondAttribute="trailing" id="GnE-h7-tKr"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="HB0-5T-NTP"/>
-                                            <constraint firstAttribute="height" constant="1420" id="HLz-hQ-nwL"/>
+                                            <constraint firstAttribute="height" constant="1550" id="HLz-hQ-nwL"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
                                             <constraint firstItem="n6U-Mw-sXv" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Js0-jw-cSi"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
                                             <constraint firstItem="GDc-P6-EV3" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="8" id="Lsq-bo-ihG"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="2Yh-Kf-8bz" secondAttribute="bottom" constant="8" id="Q9B-wZ-fUe"/>
                                             <constraint firstItem="AbB-vy-yCh" firstAttribute="leading" secondItem="CWx-3b-HSp" secondAttribute="leading" id="QKY-Xi-dne"/>
                                             <constraint firstItem="AbB-vy-yCh" firstAttribute="top" secondItem="CWx-3b-HSp" secondAttribute="bottom" constant="16" id="RMe-v0-Z5G"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="leading" secondItem="6T1-FQ-5F0" secondAttribute="leading" id="Rhp-sv-cPf"/>
@@ -834,6 +849,7 @@
                                             <constraint firstItem="Tqz-Xc-X77" firstAttribute="leading" secondItem="TyX-Nd-vml" secondAttribute="leading" id="VeZ-cz-GzN"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="trailing" secondItem="ZCa-Ky-sJk" secondAttribute="trailing" id="Vee-Ql-CM4"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="WxR-24-d7Z"/>
+                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="eEY-QJ-WyR" secondAttribute="bottom" constant="16" id="X3X-rJ-W4c"/>
                                             <constraint firstItem="Eoq-GU-M4X" firstAttribute="leading" secondItem="AbB-vy-yCh" secondAttribute="leading" id="XJi-md-Tq8"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="trailing" secondItem="ALd-1x-D8s" secondAttribute="trailing" id="XVu-xL-n1F"/>
                                             <constraint firstItem="eQx-nX-Z7D" firstAttribute="top" secondItem="Eoq-GU-M4X" secondAttribute="bottom" constant="8" id="XaC-bg-6NM"/>
@@ -851,12 +867,12 @@
                                             <constraint firstItem="Eoq-GU-M4X" firstAttribute="trailing" secondItem="AbB-vy-yCh" secondAttribute="trailing" id="jIQ-md-904"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="top" secondItem="m1C-rK-hr6" secondAttribute="bottom" constant="25" id="kDr-wb-yEl"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="leading" secondItem="ALd-1x-D8s" secondAttribute="leading" id="khr-CV-Y3J"/>
+                                            <constraint firstItem="eEY-QJ-WyR" firstAttribute="trailing" secondItem="GDc-P6-EV3" secondAttribute="trailing" id="nHV-gz-ovJ"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="leading" secondItem="66f-ut-xc9" secondAttribute="leading" id="nev-1X-dJG"/>
                                             <constraint firstItem="TyX-Nd-vml" firstAttribute="trailing" secondItem="eQx-nX-Z7D" secondAttribute="trailing" id="npT-xJ-fyq"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="o4x-Ae-iwf"/>
                                             <constraint firstItem="TyX-Nd-vml" firstAttribute="leading" secondItem="ALh-5O-zUt" secondAttribute="leading" id="oeA-oE-vRi"/>
                                             <constraint firstItem="eQx-nX-Z7D" firstAttribute="trailing" secondItem="Eoq-GU-M4X" secondAttribute="trailing" id="pGI-Jr-O2p"/>
-                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="GDc-P6-EV3" secondAttribute="bottom" constant="4" id="pSZ-Ps-Jtd"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="pU0-fB-Mqr"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="qcI-5N-bIk"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="trailing" secondItem="YiU-0q-WEb" secondAttribute="trailing" id="qik-W9-4fN"/>
@@ -866,8 +882,10 @@
                                             <constraint firstItem="ALh-5O-zUt" firstAttribute="leading" secondItem="Eoq-GU-M4X" secondAttribute="leading" id="sYz-jO-2l3"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="top" secondItem="FEF-7s-mvR" secondAttribute="bottom" constant="10" id="uYL-jT-f30"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="top" secondItem="fzM-yi-5iN" secondAttribute="top" constant="16" id="uud-EY-siF"/>
+                                            <constraint firstItem="2Yh-Kf-8bz" firstAttribute="top" secondItem="ILT-mG-F3z" secondAttribute="bottom" constant="12" id="vVz-Mr-ely"/>
+                                            <constraint firstItem="2Yh-Kf-8bz" firstAttribute="trailing" secondItem="ILT-mG-F3z" secondAttribute="trailing" id="x2Y-2J-Vow"/>
+                                            <constraint firstItem="eEY-QJ-WyR" firstAttribute="leading" secondItem="GDc-P6-EV3" secondAttribute="leading" id="y2J-bt-8jc"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="yda-eO-4bt"/>
-                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="ILT-mG-F3z" secondAttribute="bottom" constant="4" id="zEh-M7-sb7"/>
                                             <constraint firstItem="ALh-5O-zUt" firstAttribute="centerY" secondItem="eQx-nX-Z7D" secondAttribute="centerY" id="zjH-um-USI"/>
                                         </constraints>
                                     </view>
@@ -903,6 +921,7 @@
                         <outlet property="tfFilterBy" destination="66f-ut-xc9" id="mMD-fZ-gh3"/>
                         <outlet property="tfFromDt" destination="7bi-hZ-uZv" id="8JA-I1-fLi"/>
                         <outlet property="tfGoalID" destination="ILT-mG-F3z" id="pwU-Za-BSY"/>
+                        <outlet property="tfInterestID" destination="2Yh-Kf-8bz" id="7UM-Qo-02h"/>
                         <outlet property="tfInterestIds" destination="ZCa-Ky-sJk" id="QzY-ie-9Qb"/>
                         <outlet property="tfKeyword" destination="YiU-0q-WEb" id="SGR-iT-SqZ"/>
                         <outlet property="tfPage" destination="rv1-g2-bCc" id="8EU-TY-kHU"/>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -681,6 +681,9 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TyX-Nd-vml">
                                                 <rect key="frame" x="22" y="1116" width="372" height="30"/>
                                                 <state key="normal" title="Create Goal"/>
+                                                <connections>
+                                                    <action selector="onClickCreateGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="yxL-Ga-dH6"/>
+                                                </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
                                                 <rect key="frame" x="22" y="680" width="372" height="191"/>
@@ -775,6 +778,9 @@
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="eQx-nX-Z7D">
                                                 <rect key="frame" x="300" y="1076" width="94" height="32"/>
+                                                <connections>
+                                                    <action selector="didChangeValue:" destination="IhW-NR-HZQ" eventType="valueChanged" id="Uy6-Zg-ZaP"/>
+                                                </connections>
                                             </stepper>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDc-P6-EV3">
                                                 <rect key="frame" x="22" y="646" width="372" height="30"/>
@@ -877,8 +883,13 @@
                         <viewLayoutGuide key="safeArea" id="TID-fE-30B"/>
                     </view>
                     <connections>
+                        <outlet property="createGoalLogView" destination="Tqz-Xc-X77" id="VnE-0D-JJJ"/>
+                        <outlet property="lblNumberOfToDo" destination="ALh-5O-zUt" id="UKi-HU-G0x"/>
                         <outlet property="searchGoalLogView" destination="m1C-rK-hr6" id="LOd-Az-5qM"/>
                         <outlet property="tfAccessToken" destination="SHc-wl-jog" id="yPg-jP-1UY"/>
+                        <outlet property="tfCreateGoalDesc" destination="AbB-vy-yCh" id="Jbe-7X-1Lx"/>
+                        <outlet property="tfCreateGoalTitle" destination="CWx-3b-HSp" id="bgY-qw-3Sa"/>
+                        <outlet property="tfCreateToDoTitle" destination="Eoq-GU-M4X" id="loS-gY-82N"/>
                         <outlet property="tfDirection" destination="ALd-1x-D8s" id="FvH-7N-ymB"/>
                         <outlet property="tfFilterBy" destination="66f-ut-xc9" id="mMD-fZ-gh3"/>
                         <outlet property="tfFromDt" destination="7bi-hZ-uZv" id="8JA-I1-fLi"/>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -652,7 +652,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1300"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1360"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
                                                 <rect key="frame" x="22" y="16" width="372" height="32"/>
@@ -661,7 +661,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Goal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKs-sO-l08">
-                                                <rect key="frame" x="22" y="816" width="372" height="32"/>
+                                                <rect key="frame" x="22" y="896" width="372" height="32"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -672,24 +672,31 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-bz-J4f">
-                                                <rect key="frame" x="22" y="568" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="608" width="372" height="30"/>
                                                 <state key="normal" title="Search Goal"/>
                                                 <connections>
                                                     <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="kuI-g1-hXv"/>
                                                 </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TyX-Nd-vml">
-                                                <rect key="frame" x="22" y="1036" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="1116" width="372" height="30"/>
                                                 <state key="normal" title="Create Goal"/>
-                                                <connections>
-                                                    <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="ruy-Ry-OTc"/>
-                                                </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
-                                                <rect key="frame" x="22" y="600" width="372" height="191"/>
+                                                <rect key="frame" x="22" y="680" width="372" height="191"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="191" id="j9r-aF-1gV"/>
+                                                </constraints>
+                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                            </textView>
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tqz-Xc-X77">
+                                                <rect key="frame" x="22" y="1154" width="372" height="191"/>
+                                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="191" id="zIX-0t-cNK"/>
                                                 </constraints>
                                                 <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -740,40 +747,42 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal ID" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ILT-mG-F3z">
+                                                <rect key="frame" x="22" y="570" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
-                                                <rect key="frame" x="22" y="856" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="936" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
-                                                <rect key="frame" x="22" y="906" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="986" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ToDo Title (for debug)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Eoq-GU-M4X">
-                                                <rect key="frame" x="22" y="954" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="1034" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of ToDo : 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ALh-5O-zUt">
-                                                <rect key="frame" x="22" y="1001.5" width="270" height="21"/>
+                                                <rect key="frame" x="22" y="1081.5" width="270" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="eQx-nX-Z7D">
-                                                <rect key="frame" x="300" y="996" width="94" height="32"/>
+                                                <rect key="frame" x="300" y="1076" width="94" height="32"/>
                                             </stepper>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tqz-Xc-X77">
-                                                <rect key="frame" x="22" y="1074" width="372" height="191"/>
-                                                <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="191" id="zIX-0t-cNK"/>
-                                                </constraints>
-                                                <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                            </textView>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDc-P6-EV3">
+                                                <rect key="frame" x="22" y="646" width="372" height="30"/>
+                                                <state key="normal" title="Search Goal by id"/>
+                                                <connections>
+                                                    <action selector="onClickSearchByGoalID:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="HlY-bD-cSq"/>
+                                                </connections>
+                                            </button>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
@@ -786,19 +795,25 @@
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="8Vg-pG-l9j"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="centerX" secondItem="FEF-7s-mvR" secondAttribute="centerX" id="AfV-u6-yU7"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="trailing" secondItem="7bi-hZ-uZv" secondAttribute="trailing" id="D2c-fC-jqZ"/>
+                                            <constraint firstItem="ILT-mG-F3z" firstAttribute="leading" secondItem="SHc-wl-jog" secondAttribute="leading" id="DkV-wq-UN8"/>
+                                            <constraint firstItem="GDc-P6-EV3" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="GiL-Jf-Csd"/>
+                                            <constraint firstItem="ILT-mG-F3z" firstAttribute="trailing" secondItem="SHc-wl-jog" secondAttribute="trailing" id="GnE-h7-tKr"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="HB0-5T-NTP"/>
-                                            <constraint firstAttribute="height" constant="1300" id="HLz-hQ-nwL"/>
+                                            <constraint firstAttribute="height" constant="1360" id="HLz-hQ-nwL"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Hjp-ea-GuB"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
+                                            <constraint firstItem="GDc-P6-EV3" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="8" id="Lsq-bo-ihG"/>
                                             <constraint firstItem="AbB-vy-yCh" firstAttribute="leading" secondItem="CWx-3b-HSp" secondAttribute="leading" id="QKY-Xi-dne"/>
                                             <constraint firstItem="AbB-vy-yCh" firstAttribute="top" secondItem="CWx-3b-HSp" secondAttribute="bottom" constant="16" id="RMe-v0-Z5G"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="leading" secondItem="6T1-FQ-5F0" secondAttribute="leading" id="Rhp-sv-cPf"/>
                                             <constraint firstItem="Eoq-GU-M4X" firstAttribute="top" secondItem="AbB-vy-yCh" secondAttribute="bottom" constant="14" id="RiS-ew-Ybh"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="trailing" secondItem="m1C-rK-hr6" secondAttribute="trailing" id="RjK-4s-pQ6"/>
+                                            <constraint firstItem="ILT-mG-F3z" firstAttribute="top" secondItem="SHc-wl-jog" secondAttribute="bottom" constant="18" id="Rka-wI-rs8"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="leading" secondItem="fzM-yi-5iN" secondAttribute="leading" constant="22" id="S2r-3F-e2W"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="leading" secondItem="YiU-0q-WEb" secondAttribute="leading" id="TgI-7s-Y0q"/>
+                                            <constraint firstItem="GDc-P6-EV3" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="Tua-gO-Tvk"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="top" secondItem="6T1-FQ-5F0" secondAttribute="bottom" constant="18" id="U9C-dq-udm"/>
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="leading" secondItem="PHm-pv-3p8" secondAttribute="leading" id="Ust-Yd-mVU"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="leading" secondItem="ZCa-Ky-sJk" secondAttribute="leading" id="UtW-hr-unA"/>
@@ -822,12 +837,12 @@
                                             <constraint firstItem="Eoq-GU-M4X" firstAttribute="trailing" secondItem="AbB-vy-yCh" secondAttribute="trailing" id="jIQ-md-904"/>
                                             <constraint firstItem="dKs-sO-l08" firstAttribute="top" secondItem="m1C-rK-hr6" secondAttribute="bottom" constant="25" id="kDr-wb-yEl"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="leading" secondItem="ALd-1x-D8s" secondAttribute="leading" id="khr-CV-Y3J"/>
-                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="SHc-wl-jog" secondAttribute="bottom" constant="16" id="mZG-Jc-mqr"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="leading" secondItem="66f-ut-xc9" secondAttribute="leading" id="nev-1X-dJG"/>
                                             <constraint firstItem="TyX-Nd-vml" firstAttribute="trailing" secondItem="eQx-nX-Z7D" secondAttribute="trailing" id="npT-xJ-fyq"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="o4x-Ae-iwf"/>
                                             <constraint firstItem="TyX-Nd-vml" firstAttribute="leading" secondItem="ALh-5O-zUt" secondAttribute="leading" id="oeA-oE-vRi"/>
                                             <constraint firstItem="eQx-nX-Z7D" firstAttribute="trailing" secondItem="Eoq-GU-M4X" secondAttribute="trailing" id="pGI-Jr-O2p"/>
+                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="GDc-P6-EV3" secondAttribute="bottom" constant="4" id="pSZ-Ps-Jtd"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="pU0-fB-Mqr"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="qcI-5N-bIk"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="trailing" secondItem="YiU-0q-WEb" secondAttribute="trailing" id="qik-W9-4fN"/>
@@ -837,8 +852,8 @@
                                             <constraint firstItem="ALh-5O-zUt" firstAttribute="leading" secondItem="Eoq-GU-M4X" secondAttribute="leading" id="sYz-jO-2l3"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="top" secondItem="FEF-7s-mvR" secondAttribute="bottom" constant="10" id="uYL-jT-f30"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="top" secondItem="fzM-yi-5iN" secondAttribute="top" constant="16" id="uud-EY-siF"/>
-                                            <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="2" id="vsW-DS-Tp7"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="yda-eO-4bt"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="ILT-mG-F3z" secondAttribute="bottom" constant="4" id="zEh-M7-sb7"/>
                                             <constraint firstItem="ALh-5O-zUt" firstAttribute="centerY" secondItem="eQx-nX-Z7D" secondAttribute="centerY" id="zjH-um-USI"/>
                                         </constraints>
                                     </view>
@@ -867,6 +882,7 @@
                         <outlet property="tfDirection" destination="ALd-1x-D8s" id="FvH-7N-ymB"/>
                         <outlet property="tfFilterBy" destination="66f-ut-xc9" id="mMD-fZ-gh3"/>
                         <outlet property="tfFromDt" destination="7bi-hZ-uZv" id="8JA-I1-fLi"/>
+                        <outlet property="tfGoalID" destination="ILT-mG-F3z" id="pwU-Za-BSY"/>
                         <outlet property="tfInterestIds" destination="ZCa-Ky-sJk" id="QzY-ie-9Qb"/>
                         <outlet property="tfKeyword" destination="YiU-0q-WEb" id="SGR-iT-SqZ"/>
                         <outlet property="tfPage" destination="rv1-g2-bCc" id="8EU-TY-kHU"/>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -652,7 +652,7 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1360"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1420"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
                                                 <rect key="frame" x="22" y="16" width="372" height="32"/>
@@ -678,8 +678,15 @@
                                                     <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="kuI-g1-hXv"/>
                                                 </connections>
                                             </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDc-P6-EV3">
+                                                <rect key="frame" x="22" y="646" width="372" height="30"/>
+                                                <state key="normal" title="Search Goal by id"/>
+                                                <connections>
+                                                    <action selector="onClickSearchByGoalID:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="HlY-bD-cSq"/>
+                                                </connections>
+                                            </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TyX-Nd-vml">
-                                                <rect key="frame" x="22" y="1116" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="1166" width="372" height="30"/>
                                                 <state key="normal" title="Create Goal"/>
                                                 <connections>
                                                     <action selector="onClickCreateGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="yxL-Ga-dH6"/>
@@ -696,7 +703,7 @@
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                             </textView>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="Tqz-Xc-X77">
-                                                <rect key="frame" x="22" y="1154" width="372" height="191"/>
+                                                <rect key="frame" x="22" y="1204" width="372" height="191"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="191" id="zIX-0t-cNK"/>
@@ -756,39 +763,37 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Title" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
-                                                <rect key="frame" x="22" y="936" width="372" height="34"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits"/>
-                                            </textField>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
                                                 <rect key="frame" x="22" y="986" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Goal Description" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="AbB-vy-yCh">
+                                                <rect key="frame" x="22" y="1036" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="ToDo Title (for debug)" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Eoq-GU-M4X">
-                                                <rect key="frame" x="22" y="1034" width="372" height="34"/>
+                                                <rect key="frame" x="22" y="1084" width="372" height="34"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Number of ToDo : 0" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ALh-5O-zUt">
-                                                <rect key="frame" x="22" y="1081.5" width="270" height="21"/>
+                                                <rect key="frame" x="22" y="1131.5" width="270" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <stepper opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" maximumValue="100" translatesAutoresizingMaskIntoConstraints="NO" id="eQx-nX-Z7D">
-                                                <rect key="frame" x="300" y="1076" width="94" height="32"/>
+                                                <rect key="frame" x="300" y="1126" width="94" height="32"/>
                                                 <connections>
                                                     <action selector="didChangeValue:" destination="IhW-NR-HZQ" eventType="valueChanged" id="Uy6-Zg-ZaP"/>
                                                 </connections>
                                             </stepper>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GDc-P6-EV3">
-                                                <rect key="frame" x="22" y="646" width="372" height="30"/>
-                                                <state key="normal" title="Search Goal by id"/>
-                                                <connections>
-                                                    <action selector="onClickSearchByGoalID:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="HlY-bD-cSq"/>
-                                                </connections>
-                                            </button>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="AccessToken" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="n6U-Mw-sXv">
+                                                <rect key="frame" x="22" y="936" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
@@ -796,6 +801,7 @@
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="trailing" secondItem="PHm-pv-3p8" secondAttribute="trailing" id="1Af-hm-vXd"/>
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="top" secondItem="PHm-pv-3p8" secondAttribute="bottom" constant="18" id="23p-H9-v1O"/>
                                             <constraint firstItem="Tqz-Xc-X77" firstAttribute="trailing" secondItem="TyX-Nd-vml" secondAttribute="trailing" id="3pw-oV-HJL"/>
+                                            <constraint firstItem="n6U-Mw-sXv" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="3sj-np-HPT"/>
                                             <constraint firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" constant="20" id="4tW-R7-eyL"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="leading" secondItem="7bi-hZ-uZv" secondAttribute="leading" id="79E-sa-7pY"/>
                                             <constraint firstItem="CWx-3b-HSp" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="8Vg-pG-l9j"/>
@@ -805,10 +811,10 @@
                                             <constraint firstItem="GDc-P6-EV3" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="GiL-Jf-Csd"/>
                                             <constraint firstItem="ILT-mG-F3z" firstAttribute="trailing" secondItem="SHc-wl-jog" secondAttribute="trailing" id="GnE-h7-tKr"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="HB0-5T-NTP"/>
-                                            <constraint firstAttribute="height" constant="1360" id="HLz-hQ-nwL"/>
-                                            <constraint firstItem="CWx-3b-HSp" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Hjp-ea-GuB"/>
+                                            <constraint firstAttribute="height" constant="1420" id="HLz-hQ-nwL"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
+                                            <constraint firstItem="n6U-Mw-sXv" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Js0-jw-cSi"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
                                             <constraint firstItem="GDc-P6-EV3" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="8" id="Lsq-bo-ihG"/>
                                             <constraint firstItem="AbB-vy-yCh" firstAttribute="leading" secondItem="CWx-3b-HSp" secondAttribute="leading" id="QKY-Xi-dne"/>
@@ -821,6 +827,7 @@
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="leading" secondItem="YiU-0q-WEb" secondAttribute="leading" id="TgI-7s-Y0q"/>
                                             <constraint firstItem="GDc-P6-EV3" firstAttribute="trailing" secondItem="T3m-bz-J4f" secondAttribute="trailing" id="Tua-gO-Tvk"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="top" secondItem="6T1-FQ-5F0" secondAttribute="bottom" constant="18" id="U9C-dq-udm"/>
+                                            <constraint firstItem="n6U-Mw-sXv" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="UhJ-aP-Utx"/>
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="leading" secondItem="PHm-pv-3p8" secondAttribute="leading" id="Ust-Yd-mVU"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="leading" secondItem="ZCa-Ky-sJk" secondAttribute="leading" id="UtW-hr-unA"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="leading" secondItem="17V-Z9-gUh" secondAttribute="leading" id="Uw8-Vc-NA6"/>
@@ -836,6 +843,7 @@
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="top" secondItem="YiU-0q-WEb" secondAttribute="bottom" constant="16" id="cgF-Fs-xXM"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="top" secondItem="66f-ut-xc9" secondAttribute="bottom" constant="15" id="cmI-ru-byd"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" id="cv4-P7-WXS"/>
+                                            <constraint firstItem="CWx-3b-HSp" firstAttribute="top" secondItem="n6U-Mw-sXv" secondAttribute="bottom" constant="16" id="d7f-uI-nvc"/>
                                             <constraint firstItem="SHc-wl-jog" firstAttribute="top" secondItem="rv1-g2-bCc" secondAttribute="bottom" constant="20" id="evR-vw-kkJ"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="trailing" secondItem="17V-Z9-gUh" secondAttribute="trailing" id="fCq-0w-3ic"/>
                                             <constraint firstItem="Tqz-Xc-X77" firstAttribute="top" secondItem="TyX-Nd-vml" secondAttribute="bottom" constant="8" id="gya-wp-vJt"/>
@@ -889,6 +897,7 @@
                         <outlet property="tfAccessToken" destination="SHc-wl-jog" id="yPg-jP-1UY"/>
                         <outlet property="tfCreateGoalDesc" destination="AbB-vy-yCh" id="Jbe-7X-1Lx"/>
                         <outlet property="tfCreateGoalTitle" destination="CWx-3b-HSp" id="bgY-qw-3Sa"/>
+                        <outlet property="tfCreateGoalToken" destination="n6U-Mw-sXv" id="XVb-V5-VlS"/>
                         <outlet property="tfCreateToDoTitle" destination="Eoq-GU-M4X" id="loS-gY-82N"/>
                         <outlet property="tfDirection" destination="ALd-1x-D8s" id="FvH-7N-ymB"/>
                         <outlet property="tfFilterBy" destination="66f-ut-xc9" id="mMD-fZ-gh3"/>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -643,7 +643,7 @@
         <!--GoalAPI View Controller-->
         <scene sceneID="lqi-xw-ZxL">
             <objects>
-                <viewController storyboardIdentifier="apiTestJobInfoVC" id="IhW-NR-HZQ" customClass="GoalAPIViewController" customModule="erooja" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="apiTestGoalVC" id="IhW-NR-HZQ" customClass="GoalAPIViewController" customModule="erooja" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="bZx-Zn-bZL">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/erooja/storyboard/EroojaDev.storyboard
+++ b/erooja/storyboard/EroojaDev.storyboard
@@ -652,10 +652,16 @@
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="fzM-yi-5iN">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="900"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="1800"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Goal API" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FEF-7s-mvR">
                                                 <rect key="frame" x="22" y="16" width="372" height="32"/>
+                                                <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Create Goal" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dKs-sO-l08">
+                                                <rect key="frame" x="22" y="816" width="372" height="32"/>
                                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="26"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -666,11 +672,14 @@
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="T3m-bz-J4f">
-                                                <rect key="frame" x="22" y="509" width="372" height="30"/>
+                                                <rect key="frame" x="22" y="568" width="372" height="30"/>
                                                 <state key="normal" title="Search Goal"/>
+                                                <connections>
+                                                    <action selector="onClickSearchGoal:" destination="IhW-NR-HZQ" eventType="touchUpInside" id="kuI-g1-hXv"/>
+                                                </connections>
                                             </button>
                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" text="Log Message" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="m1C-rK-hr6">
-                                                <rect key="frame" x="22" y="541" width="372" height="191"/>
+                                                <rect key="frame" x="22" y="600" width="372" height="191"/>
                                                 <color key="backgroundColor" systemColor="systemGray6Color" red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="191" id="j9r-aF-1gV"/>
@@ -719,6 +728,16 @@
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits"/>
                                             </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="page : 0" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CWx-3b-HSp">
+                                                <rect key="frame" x="22" y="856" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
+                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Access Token" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SHc-wl-jog">
+                                                <rect key="frame" x="22" y="518" width="372" height="34"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                <textInputTraits key="textInputTraits"/>
+                                            </textField>
                                         </subviews>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                         <constraints>
@@ -726,14 +745,17 @@
                                             <constraint firstItem="rv1-g2-bCc" firstAttribute="top" secondItem="PHm-pv-3p8" secondAttribute="bottom" constant="18" id="23p-H9-v1O"/>
                                             <constraint firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" constant="20" id="4tW-R7-eyL"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="leading" secondItem="7bi-hZ-uZv" secondAttribute="leading" id="79E-sa-7pY"/>
-                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="rv1-g2-bCc" secondAttribute="bottom" constant="11" id="7h0-PX-CMk"/>
+                                            <constraint firstItem="CWx-3b-HSp" firstAttribute="leading" secondItem="dKs-sO-l08" secondAttribute="leading" id="8Vg-pG-l9j"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="centerX" secondItem="FEF-7s-mvR" secondAttribute="centerX" id="AfV-u6-yU7"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="trailing" secondItem="7bi-hZ-uZv" secondAttribute="trailing" id="D2c-fC-jqZ"/>
-                                            <constraint firstAttribute="height" constant="900" id="HLz-hQ-nwL"/>
+                                            <constraint firstItem="SHc-wl-jog" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="HB0-5T-NTP"/>
+                                            <constraint firstAttribute="height" constant="1800" id="HLz-hQ-nwL"/>
+                                            <constraint firstItem="CWx-3b-HSp" firstAttribute="top" secondItem="dKs-sO-l08" secondAttribute="bottom" constant="8" id="Hjp-ea-GuB"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="top" secondItem="17V-Z9-gUh" secondAttribute="bottom" constant="17" id="ITQ-9L-4bK"/>
                                             <constraint firstItem="17V-Z9-gUh" firstAttribute="top" secondItem="7bi-hZ-uZv" secondAttribute="bottom" constant="16" id="JJ3-cu-lwa"/>
                                             <constraint firstItem="ALd-1x-D8s" firstAttribute="top" secondItem="ZCa-Ky-sJk" secondAttribute="bottom" constant="18" id="KVP-tr-JdY"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="leading" secondItem="6T1-FQ-5F0" secondAttribute="leading" id="Rhp-sv-cPf"/>
+                                            <constraint firstItem="dKs-sO-l08" firstAttribute="trailing" secondItem="m1C-rK-hr6" secondAttribute="trailing" id="RjK-4s-pQ6"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="leading" secondItem="fzM-yi-5iN" secondAttribute="leading" constant="22" id="S2r-3F-e2W"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="leading" secondItem="YiU-0q-WEb" secondAttribute="leading" id="TgI-7s-Y0q"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="top" secondItem="6T1-FQ-5F0" secondAttribute="bottom" constant="18" id="U9C-dq-udm"/>
@@ -744,17 +766,23 @@
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="WxR-24-d7Z"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="trailing" secondItem="ALd-1x-D8s" secondAttribute="trailing" id="XVu-xL-n1F"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="top" secondItem="ALd-1x-D8s" secondAttribute="bottom" constant="16" id="aYb-sW-hcH"/>
+                                            <constraint firstItem="dKs-sO-l08" firstAttribute="leading" secondItem="m1C-rK-hr6" secondAttribute="leading" id="ags-I9-3lc"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="top" secondItem="YiU-0q-WEb" secondAttribute="bottom" constant="16" id="cgF-Fs-xXM"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="top" secondItem="66f-ut-xc9" secondAttribute="bottom" constant="15" id="cmI-ru-byd"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="trailing" secondItem="66f-ut-xc9" secondAttribute="trailing" id="cv4-P7-WXS"/>
+                                            <constraint firstItem="SHc-wl-jog" firstAttribute="top" secondItem="rv1-g2-bCc" secondAttribute="bottom" constant="20" id="evR-vw-kkJ"/>
                                             <constraint firstItem="ZCa-Ky-sJk" firstAttribute="trailing" secondItem="17V-Z9-gUh" secondAttribute="trailing" id="fCq-0w-3ic"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="leading" secondItem="FEF-7s-mvR" secondAttribute="leading" id="hvC-z5-Hcw"/>
+                                            <constraint firstItem="dKs-sO-l08" firstAttribute="top" secondItem="m1C-rK-hr6" secondAttribute="bottom" constant="25" id="kDr-wb-yEl"/>
                                             <constraint firstItem="6T1-FQ-5F0" firstAttribute="leading" secondItem="ALd-1x-D8s" secondAttribute="leading" id="khr-CV-Y3J"/>
+                                            <constraint firstItem="T3m-bz-J4f" firstAttribute="top" secondItem="SHc-wl-jog" secondAttribute="bottom" constant="16" id="mZG-Jc-mqr"/>
                                             <constraint firstItem="YiU-0q-WEb" firstAttribute="leading" secondItem="66f-ut-xc9" secondAttribute="leading" id="nev-1X-dJG"/>
+                                            <constraint firstItem="CWx-3b-HSp" firstAttribute="trailing" secondItem="dKs-sO-l08" secondAttribute="trailing" id="o4x-Ae-iwf"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="leading" secondItem="T3m-bz-J4f" secondAttribute="leading" id="pU0-fB-Mqr"/>
                                             <constraint firstItem="T3m-bz-J4f" firstAttribute="trailing" secondItem="rv1-g2-bCc" secondAttribute="trailing" id="qcI-5N-bIk"/>
                                             <constraint firstItem="7bi-hZ-uZv" firstAttribute="trailing" secondItem="YiU-0q-WEb" secondAttribute="trailing" id="qik-W9-4fN"/>
                                             <constraint firstItem="PHm-pv-3p8" firstAttribute="trailing" secondItem="6T1-FQ-5F0" secondAttribute="trailing" id="rG9-ZG-65j"/>
+                                            <constraint firstItem="SHc-wl-jog" firstAttribute="leading" secondItem="rv1-g2-bCc" secondAttribute="leading" id="sMn-xX-ubu"/>
                                             <constraint firstItem="66f-ut-xc9" firstAttribute="top" secondItem="FEF-7s-mvR" secondAttribute="bottom" constant="10" id="uYL-jT-f30"/>
                                             <constraint firstItem="FEF-7s-mvR" firstAttribute="top" secondItem="fzM-yi-5iN" secondAttribute="top" constant="16" id="uud-EY-siF"/>
                                             <constraint firstItem="m1C-rK-hr6" firstAttribute="top" secondItem="T3m-bz-J4f" secondAttribute="bottom" constant="2" id="vsW-DS-Tp7"/>
@@ -780,6 +808,19 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="TID-fE-30B"/>
                     </view>
+                    <connections>
+                        <outlet property="searchGoalLogView" destination="m1C-rK-hr6" id="LOd-Az-5qM"/>
+                        <outlet property="tfAccessToken" destination="SHc-wl-jog" id="yPg-jP-1UY"/>
+                        <outlet property="tfDirection" destination="ALd-1x-D8s" id="FvH-7N-ymB"/>
+                        <outlet property="tfFilterBy" destination="66f-ut-xc9" id="mMD-fZ-gh3"/>
+                        <outlet property="tfFromDt" destination="7bi-hZ-uZv" id="8JA-I1-fLi"/>
+                        <outlet property="tfInterestIds" destination="ZCa-Ky-sJk" id="QzY-ie-9Qb"/>
+                        <outlet property="tfKeyword" destination="YiU-0q-WEb" id="SGR-iT-SqZ"/>
+                        <outlet property="tfPage" destination="rv1-g2-bCc" id="8EU-TY-kHU"/>
+                        <outlet property="tfSize" destination="PHm-pv-3p8" id="pKu-al-Cjr"/>
+                        <outlet property="tfSort" destination="6T1-FQ-5F0" id="0nK-Rv-UV7"/>
+                        <outlet property="tfToDt" destination="17V-Z9-gUh" id="ubt-ZD-7F6"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JG6-qx-xxl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>


### PR DESCRIPTION
[2020. 05. 02. 기준 구현된 API 현황]
- 목표 생성하기
- 목표 상세조회 (goad Id로)
- 목표 리스트 조회 (Interest Id로)
- 목표 검색 (Query String)
- 직군/직무 단일 조회
- 직군과 직무 함께 불러오기
- 직군 불러오기
- 사용자의 직군/직무 추가하기
- 사용자의 직군/직무 리스트 추가하기
- 사용자의 직군/직무 불러오기
- 저장된 (현재 + 이전)프로필 사진 경로들 불러오기
- 프로필 사진 업데이트
- 유저정보 업데이트
- 포함된 토큰의 유저 기본 정보 얻기
- 닉네임 업데이트
- 닉네임 중복 확인
- 토큰 갱신
- 토큰, 갱신 토큰 발급 (카카오)